### PR TITLE
China optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bindings": "1.5.0",
     "core-js": "3.8.2",
     "direct-vuex": "0.12.0",
+    "electron-fetch": "^1.7.4",
     "electron-log": "4.3.1",
     "electron-store": "6.0.1",
     "electron-updater": "4.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w3champions",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "private": true,
   "description": "Always stay up to date with this Launcher for the community Ladder Warcraft 3 Champions.",
   "author": "simonheiss87@gmail.com",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,25 +1,28 @@
 <template>
   <div id="app" class="app-container">
-    <HeadLine />
-    <div v-if="!isLoggedIn" >
-      <LoadingSpinner v-if="regionChoosen" text="Logging in..."/>
-      <LoadingSpinner v-else text="Choose the region of your battle net account (this does not affect where you are actually playing)"/>
-      <div class="gw-selection-wrapper" v-if="!regionChoosen">
-        <div style="display: flex; flex-direction: row; cursor: pointer" @click="() => loginAt(loginGWs.eu)">
-          <div class="gw-selection gw-select-eu"/>
-          <div style="font-size: 40px; line-height: 60px; padding-left: 10px; padding-right: 10px"> / </div>
-          <div class="gw-selection gw-select-us"/>
+    <template>
+      <HeadLine />
+      <LoadingSpinner v-if="!selectedEndpoint" text="Selecting server..."/>
+      <div v-if="!isLoggedIn" >
+        <LoadingSpinner v-if="regionChoosen" text="Logging in..."/>
+        <LoadingSpinner v-else text="Choose the region of your battle net account (this does not affect where you are actually playing)"/>
+        <div class="gw-selection-wrapper" v-if="!regionChoosen">
+          <div style="display: flex; flex-direction: row; cursor: pointer" @click="() => loginAt(loginGWs.eu)">
+            <div class="gw-selection gw-select-eu"/>
+            <div style="font-size: 40px; line-height: 60px; padding-left: 10px; padding-right: 10px"> / </div>
+            <div class="gw-selection gw-select-us"/>
+          </div>
+          <div class="gw-selection gw-select-cn" @click="() => loginAt(loginGWs.cn)"/>
         </div>
-        <div class="gw-selection gw-select-cn" @click="() => loginAt(loginGWs.cn)"/>
       </div>
-    </div>
-    <div class="content-modal-wrapper">
-      <div class="static-bg" />
-      <div class="content-modal">
-        <router-view />
+      <div class="content-modal-wrapper">
+        <div class="static-bg" />
+        <div class="content-modal">
+          <router-view />
+        </div>
       </div>
-    </div>
-    <div id='close-button' class="close-button" @click="closeApp" />
+      <div id='close-button' class="close-button" @click="closeApp" />
+    </template>
   </div>
 </template>
 
@@ -36,6 +39,7 @@ const keyboard = window.require("send-keys-native/build/Release/send-keys-native
 const { remote } = window.require("electron");
 const { ipcRenderer } = window.require('electron')
 
+
 @Component({
   components: {LoadingSpinner, HeadLine}
 })
@@ -50,32 +54,34 @@ export default class App extends Vue {
     ipcRenderer.on('blizzard-window-closed-without-auth', () => {
       store.dispatch.setLoginGateway(LoginGW.none);
     })
+    
+    ipcRenderer.on('w3c-check-for-update-finished', async () => {
+      this.$store.direct.dispatch.loadIsTestMode();
 
-    this.$store.direct.dispatch.loadIsTestMode();
-    this.$store.direct.dispatch.loadIsChinaProxyEnabled();
-    this.$store.direct.dispatch.loadOsMode();
-    this.$store.direct.dispatch.loadAuthToken();
+      this.$store.direct.dispatch.loadOsMode();
+      this.$store.direct.dispatch.loadAuthToken();
 
-    this.makeSureNumpadIsEnabled()
+      this.makeSureNumpadIsEnabled()
 
-    await this.$store.direct.dispatch.loadNews();
+      await this.$store.direct.dispatch.loadNews();
 
-    logger.info(remote.app.getPath('userData'))
-    this.$store.direct.dispatch.hotKeys.loadHotkeyFabSettings();
-    this.$store.direct.dispatch.hotKeys.loadToggleKey();
-    this.$store.direct.dispatch.hotKeys.loadHotKeys();
-    this.$store.direct.dispatch.hotKeys.setToggleKey(this.$store.direct.state.hotKeys.toggleButton);
-    this.$store.direct.dispatch.hotKeys.loadManualMode();
-    this.$store.direct.dispatch.hotKeys.loadIsClassicIcons();
+      logger.info(remote.app.getPath('userData'))
+      this.$store.direct.dispatch.hotKeys.loadHotkeyFabSettings();
+      this.$store.direct.dispatch.hotKeys.loadToggleKey();
+      this.$store.direct.dispatch.hotKeys.loadHotKeys();
+      this.$store.direct.dispatch.hotKeys.setToggleKey(this.$store.direct.state.hotKeys.toggleButton);
+      this.$store.direct.dispatch.hotKeys.loadManualMode();
+      this.$store.direct.dispatch.hotKeys.loadIsClassicIcons();
 
-    this.$store.direct.dispatch.updateHandling.loadAllPaths();
-    await this.$store.direct.dispatch.updateHandling.loadOnlineW3CVersion();
-    await this.$store.direct.dispatch.updateHandling.loadCurrentLauncherVersion();
-    await this.$store.direct.dispatch.updateHandling.loadCurrentW3CVersion();
-    await this.$store.direct.dispatch.colorPicker.loadIsTeamColorsEnabled();
-    await this.$store.direct.dispatch.colorPicker.loadColors();
+      this.$store.direct.dispatch.updateHandling.loadAllPaths();
+      await this.$store.direct.dispatch.updateHandling.loadOnlineW3CVersion();
+      await this.$store.direct.dispatch.updateHandling.loadCurrentLauncherVersion();
+      await this.$store.direct.dispatch.updateHandling.loadCurrentW3CVersion();
+      await this.$store.direct.dispatch.colorPicker.loadIsTeamColorsEnabled();
+      await this.$store.direct.dispatch.colorPicker.loadColors();
 
-    await this.updateStrategy.updateIfNeeded();
+      await this.updateStrategy.updateIfNeeded();
+    })
   }
 
   get regionChoosen() {
@@ -89,6 +95,10 @@ export default class App extends Vue {
   get isLoggedIn() {
     if (!OAUTH_ENABLED) return true;
     return this.$store.direct.state.w3cToken
+  }
+
+  get selectedEndpoint() {
+    return this.$store.direct.state.selectedEndpoint
   }
 
   public async loginAt(gateway: LoginGW) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,10 +54,12 @@ export default class App extends Vue {
     ipcRenderer.on('blizzard-window-closed-without-auth', () => {
       store.dispatch.setLoginGateway(LoginGW.none);
     })
-    
-    ipcRenderer.on('w3c-check-for-update-finished', async () => {
-      this.$store.direct.dispatch.loadIsTestMode();
 
+    this.$store.direct.dispatch.loadIsTestMode();
+
+    ipcRenderer.invoke('w3c-select-endpoint', store.state.isTest);
+    
+    ipcRenderer.on('w3c-background-init-finished', async () => {
       this.$store.direct.dispatch.loadOsMode();
       this.$store.direct.dispatch.loadAuthToken();
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -58,31 +58,35 @@ export default class App extends Vue {
     this.$store.direct.dispatch.loadIsTestMode();
 
     ipcRenderer.invoke('w3c-select-endpoint', store.state.isTest);
-    
-    ipcRenderer.on('w3c-background-init-finished', async () => {
-      this.$store.direct.dispatch.loadOsMode();
-      this.$store.direct.dispatch.loadAuthToken();
+    ipcRenderer.on('w3c-endpoint-selected', () => {
+      Vue.nextTick(async () => {
+        const state = this.$store.direct.state
+        if (state.selectedEndpoint) {
+          this.$store.direct.dispatch.loadOsMode();
+          this.$store.direct.dispatch.loadAuthToken();
 
-      this.makeSureNumpadIsEnabled()
+          this.makeSureNumpadIsEnabled()
 
-      await this.$store.direct.dispatch.loadNews();
+          this.$store.direct.dispatch.loadNews();
 
-      logger.info(remote.app.getPath('userData'))
-      this.$store.direct.dispatch.hotKeys.loadHotkeyFabSettings();
-      this.$store.direct.dispatch.hotKeys.loadToggleKey();
-      this.$store.direct.dispatch.hotKeys.loadHotKeys();
-      this.$store.direct.dispatch.hotKeys.setToggleKey(this.$store.direct.state.hotKeys.toggleButton);
-      this.$store.direct.dispatch.hotKeys.loadManualMode();
-      this.$store.direct.dispatch.hotKeys.loadIsClassicIcons();
+          logger.info(remote.app.getPath('userData'))
+          this.$store.direct.dispatch.hotKeys.loadHotkeyFabSettings();
+          this.$store.direct.dispatch.hotKeys.loadToggleKey();
+          this.$store.direct.dispatch.hotKeys.loadHotKeys();
+          this.$store.direct.dispatch.hotKeys.setToggleKey(this.$store.direct.state.hotKeys.toggleButton);
+          this.$store.direct.dispatch.hotKeys.loadManualMode();
+          this.$store.direct.dispatch.hotKeys.loadIsClassicIcons();
 
-      this.$store.direct.dispatch.updateHandling.loadAllPaths();
-      await this.$store.direct.dispatch.updateHandling.loadOnlineW3CVersion();
-      await this.$store.direct.dispatch.updateHandling.loadCurrentLauncherVersion();
-      await this.$store.direct.dispatch.updateHandling.loadCurrentW3CVersion();
-      await this.$store.direct.dispatch.colorPicker.loadIsTeamColorsEnabled();
-      await this.$store.direct.dispatch.colorPicker.loadColors();
+          this.$store.direct.dispatch.updateHandling.loadAllPaths();
+          await this.$store.direct.dispatch.updateHandling.loadOnlineW3CVersion();
+          await this.$store.direct.dispatch.updateHandling.loadCurrentLauncherVersion();
+          await this.$store.direct.dispatch.updateHandling.loadCurrentW3CVersion();
+          await this.$store.direct.dispatch.colorPicker.loadIsTeamColorsEnabled();
+          await this.$store.direct.dispatch.colorPicker.loadColors();
 
-      await this.updateStrategy.updateIfNeeded();
+          await this.updateStrategy.updateIfNeeded();
+        }
+      })
     })
   }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -52,6 +52,7 @@ export default class App extends Vue {
     })
 
     this.$store.direct.dispatch.loadIsTestMode();
+    this.$store.direct.dispatch.loadIsChinaProxyEnabled();
     this.$store.direct.dispatch.loadOsMode();
     this.$store.direct.dispatch.loadAuthToken();
 

--- a/src/background-thread/endpoint/endpoint.service.ts
+++ b/src/background-thread/endpoint/endpoint.service.ts
@@ -11,19 +11,19 @@ export interface IEndpoint {
 }
 
 const ENDPOINTS_PROD: IEndpoint[] = [
-  // {
-  //   id: "Europe",
-  //   updateUrl: "https://update-service.w3champions.com/",
-  //   newsUrl: "https://statistic-service.w3champions.com/",
-  //   identificationUrl: "https://identification-service.w3champions.com/",
-  //   floControllerHost: "service.w3flo.com",
-  // },
+  {
+    id: "Europe",
+    updateUrl: "https://update-service.w3champions.com/",
+    newsUrl: "https://statistic-service.w3champions.com/",
+    identificationUrl: "https://identification-service.w3champions.com/",
+    floControllerHost: "service.w3flo.com",
+  },
   {
     id: "中国",
     updateUrl: "http://123.57.23.5:25053/",
     newsUrl: "http://123.57.23.5:25052/",
     identificationUrl: "http://123.57.23.5:25051/",
-    floControllerHost: "ea2d46.pathx.ucloudgda.com",
+    floControllerHost: "123.57.23.5",
     staticBaseUpdateFileUrl: 'https://w3champions.oss-cn-shanghai.aliyuncs.com/update-service-content/'
   },
 ];

--- a/src/background-thread/endpoint/endpoint.service.ts
+++ b/src/background-thread/endpoint/endpoint.service.ts
@@ -8,7 +8,7 @@ export interface IEndpoint {
   identificationUrl: string;
   floControllerHost: string;
   overrideUpdateFileDownloadUrl?: string;
-  overrideIngameJsUrl?: string,
+  overrideRemoteWebUIFileName?: string,
 }
 
 const ENDPOINTS_PROD: IEndpoint[] = [
@@ -26,7 +26,7 @@ const ENDPOINTS_PROD: IEndpoint[] = [
     identificationUrl: "http://123.57.23.5:25051/",
     floControllerHost: "ea2d46.pathx.ucloudgda.com",
     overrideUpdateFileDownloadUrl: "https://w3champions.oss-cn-shanghai.aliyuncs.com/update-service-content/",
-    overrideIngameJsUrl: "https://w3champions.oss-cn-shanghai.aliyuncs.com/ingame/w3champions.js"
+    overrideRemoteWebUIFileName: "china-webui.zip"
   },
 ];
 
@@ -44,7 +44,7 @@ export class EndpointService {
   private window: BrowserWindow | null = null
 
   constructor() {
-    ipcMain.handle('w3c-select-endpoint', async (evt: unknown, isTest: boolean) => {
+    ipcMain.handle('w3c-select-endpoint', async (_evt: unknown, isTest: boolean) => {
       try {
         const endpoint = await this.selectFastestEndpoint(isTest);
         this.window?.webContents.send('w3c-endpoint-selected', endpoint);
@@ -53,14 +53,6 @@ export class EndpointService {
         console.log(e);
       }
     });
-
-    ipcMain.handle('w3c-write-webui', (evt: unknown, path, url) => {
-      try {
-        fs.writeFileSync(path, this.getWebUISrc(url))
-      } catch(e) {
-        console.log(e);
-      }
-    })
   }
 
   public setWindow(window: BrowserWindow) {
@@ -74,44 +66,11 @@ export class EndpointService {
     const endpoints = isTest ? TEST_ENDPOINTS : ENDPOINTS_PROD;
     selected = await Promise.any(
       endpoints.map(async (i) => {
-        // await fetch(`${i.updateUrl}api/client-version`);
+        await fetch(`${i.updateUrl}api/client-version`);
         return i;
       })
     );
     return selected;
-  }
-
-  private getWebUISrc(url: string) {
-    return `<!DOCTYPE html>
-    <html>
-        <head>
-            <meta charset="utf-8" />
-            <title>Warcraft 3 UI</title>
-            <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, minimal-ui" />
-            <script>
-                window.__DEBUG = new Boolean('').valueOf();
-            </script>
-        </head>
-        <body>
-            <div id="root"></div>
-            <div id="portal"></div>
-        
-        <script>
-          var logCalls = [];
-          var w3cClientVersion = 1;
-          console.origLog = console.log;
-          console.log = (...args) => {
-            logCalls.push(...args);
-            console.origLog("log");
-            console.origLog(...args);
-          }
-    
-        </script>
-            <script src="GlueManager.js"></script>
-        <script src="${url}"></script>
-        </body>
-    </html>
-    `
   }
 }
 

--- a/src/background-thread/endpoint/endpoint.service.ts
+++ b/src/background-thread/endpoint/endpoint.service.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, ipcMain } from "electron";
-import fs from 'fs'
+import fetch from 'electron-fetch'
 
 export interface IEndpoint {
   id: string;
@@ -7,26 +7,24 @@ export interface IEndpoint {
   newsUrl: string;
   identificationUrl: string;
   floControllerHost: string;
-  overrideUpdateFileDownloadUrl?: string;
-  overrideRemoteWebUIFileName?: string,
+  staticBaseUpdateFileUrl?: string;
 }
 
 const ENDPOINTS_PROD: IEndpoint[] = [
-  {
-    id: "Europe",
-    updateUrl: "https://update-service.w3champions.com/",
-    newsUrl: "https://statistic-service.w3champions.com/",
-    identificationUrl: "https://identification-service.w3champions.com/",
-    floControllerHost: "service.w3flo.com",
-  },
+  // {
+  //   id: "Europe",
+  //   updateUrl: "https://update-service.w3champions.com/",
+  //   newsUrl: "https://statistic-service.w3champions.com/",
+  //   identificationUrl: "https://identification-service.w3champions.com/",
+  //   floControllerHost: "service.w3flo.com",
+  // },
   {
     id: "中国",
     updateUrl: "http://123.57.23.5:25053/",
     newsUrl: "http://123.57.23.5:25052/",
     identificationUrl: "http://123.57.23.5:25051/",
     floControllerHost: "ea2d46.pathx.ucloudgda.com",
-    overrideUpdateFileDownloadUrl: "https://w3champions.oss-cn-shanghai.aliyuncs.com/update-service-content/",
-    overrideRemoteWebUIFileName: "china-webui.zip"
+    staticBaseUpdateFileUrl: 'https://w3champions.oss-cn-shanghai.aliyuncs.com/update-service-content/'
   },
 ];
 

--- a/src/background-thread/flo/flo-utils.services.ts
+++ b/src/background-thread/flo/flo-utils.services.ts
@@ -1,0 +1,41 @@
+import { ipcMain, app } from 'electron';
+import sudo from "sudo-prompt";
+import path from 'path'
+
+class FloUtilsService {
+  private isDev = process.argv.includes('--dev');
+  private isWindows = process.platform === 'win32'
+  registerHandlers() {
+    ipcMain.handle('flo-add-firewall-rule', async () => {
+      if (!this.isWindows) {
+        return
+      }
+
+      const path = this.getFloWorkerExecutablePath()
+      console.log("flo worker: " + path);
+      sudo.exec(`netsh firewall add allowedprogram "${path}" "FLO" ENABLE`, {
+        name: 'Warcraft 3 Champions',
+      }, (err?: Error) => {
+          if (err) {
+              console.log(err)
+          }
+      });
+    });
+  }
+
+  getFloWorkerExecutablePath() {
+    const floExecutable = this.isWindows ? 'flo-worker.exe' : 'flo-worker';
+    let floWorkerFolderPath: string;
+    if (this.isDev) {
+        const appPath = app.getAppPath();
+        let rootFolder = appPath.replace('\\dist_electron', '');
+        rootFolder = rootFolder.replace('/dist_electron', '');
+        floWorkerFolderPath =  path.join(rootFolder, `libs`);
+    } else {
+        floWorkerFolderPath = path.join(`${app.getAppPath()}.unpacked`);
+    }
+    return path.join(floWorkerFolderPath, floExecutable)
+  }
+}
+
+export const floUtilsService = new FloUtilsService();

--- a/src/background.ts
+++ b/src/background.ts
@@ -148,10 +148,6 @@ if (!gotTheLock) {
       logger.error(e);
       error = e
     }
-
-    // Endpoint detection and auto-update check done
-    // tell App.vue to start loading
-    win?.webContents.send('w3c-background-init-finished');
   })
 
   // This method will be called when Electron has finished

--- a/src/background.ts
+++ b/src/background.ts
@@ -6,6 +6,7 @@ import { createProtocol } from 'vue-cli-plugin-electron-builder/lib'
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer'
 import path from 'path';
 import { floNetworkTestService } from './background-thread/flo/flo-network-test.service'
+import { endpontService } from './background-thread/endpoint/endpoint.service'
 const isDevelopment = process.env.NODE_ENV !== 'production'
 declare const __static: string;
 
@@ -77,6 +78,7 @@ function createWindow() {
   });
 
   floNetworkTestService.setWindow(win);
+  endpontService.setWindow(win);
 
   if (process.env.WEBPACK_DEV_SERVER_URL) {
     // Load the url of the dev server if in development mode
@@ -149,7 +151,7 @@ if (!gotTheLock) {
 
     // Endpoint detection and auto-update check done
     // tell App.vue to start loading
-    win?.webContents.send('w3c-check-for-update-finished');
+    win?.webContents.send('w3c-background-init-finished');
   })
 
   // This method will be called when Electron has finished

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,19 +1,3 @@
-export const UPDATE_URL_PROD = "https://update-service.w3champions.com/";
-export const UPDATE_URL_PROD_CHINA = "http://123.57.23.5:25053/";
-export const UPDATE_URL_TEST = "https://update-service.test.w3champions.com/";
-
-export const NEWS_URL_PROD = "https://statistic-service.w3champions.com/";
-export const NEWS_URL_PROD_CHINA = "http://123.57.23.5:25052/";
-export const NEWS_URL_TEST = "https://statistic-service.test.w3champions.com/";
-
-export const IDENTIFICATION_URL_PROD = "https://identification-service.w3champions.com/";
-export const IDENTIFICATION_URL_PROD_CHINA = "http://123.57.23.5:25051/";
-export const IDENTIFICATION_URL_TEST = "https://identification-service.test.w3champions.com/";
-
-export const FLO_CONTROLLER_HOST_URL_PROD = 'service.w3flo.com';
-export const FLO_CONTROLLER_HOST_URL_PROD_CHINA = 'ea2d46.pathx.ucloudgda.com';
-export const FLO_CONTROLLER_HOST_URL_TEST = '157.90.1.251';
-
 export const IDENTIFICATION_PUBLIC_KEY_PROD = `-----BEGIN PUBLIC KEY-----
 MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAtm4he5E9SkGn3hI2cSIH
 H+3+jxeP/J5oSrOecUik7rwOHI4nKLhvfk1mwIsyQkMXRgEGXkToPTk5CAgkTvq9
@@ -47,35 +31,3 @@ sYbv9oAYja2AuGxDba1MJHUCAwEAAQ==
 `
 
 export const OAUTH_ENABLED = false;
-
-export const CHINA_ALIYUN_OSS_URL = "http://w3champions.oss-cn-shanghai.aliyuncs.com";
-export const CHINA_WEBUI_SRC= `<!DOCTYPE html>
-<html>
-    <head>
-        <meta charset="utf-8" />
-        <title>Warcraft 3 UI</title>
-        <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, minimal-ui" />
-        <script>
-            window.__DEBUG = new Boolean('').valueOf();
-        </script>
-    </head>
-    <body>
-        <div id="root"></div>
-        <div id="portal"></div>
-		
-		<script>
-			var logCalls = [];
-			var w3cClientVersion = 1;
-			console.origLog = console.log;
-			console.log = (...args) => {
-				logCalls.push(...args);
-				console.origLog("log");
-				console.origLog(...args);
-			}
-
-		</script>
-        <script src="GlueManager.js"></script>
-		<script src="${CHINA_ALIYUN_OSS_URL}/ingame/w3champions.js"></script>
-    </body>
-</html>
-`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,13 +1,13 @@
-export const UPDATE_URL_PROD = "https://update-service.w3champions.com/";
+export const UPDATE_URL_PROD = "http://123.57.23.5:25053/";
 export const UPDATE_URL_TEST = "https://update-service.test.w3champions.com/";
 
-export const NEWS_URL_PROD = "https://statistic-service.w3champions.com/";
+export const NEWS_URL_PROD = "http://123.57.23.5:25052/";
 export const NEWS_URL_TEST = "https://statistic-service.test.w3champions.com/";
 
-export const IDENTIFICATION_URL_PROD = "https://identification-service.w3champions.com/";
+export const IDENTIFICATION_URL_PROD = "http://123.57.23.5:25051/";
 export const IDENTIFICATION_URL_TEST = "https://identification-service.test.w3champions.com/";
 
-export const FLO_CONTROLLER_HOST_URL_PROD = 'service.w3flo.com';
+export const FLO_CONTROLLER_HOST_URL_PROD = 'ea2d46.pathx.ucloudgda.com';
 export const FLO_CONTROLLER_HOST_URL_TEST = '157.90.1.251';
 
 export const IDENTIFICATION_PUBLIC_KEY_PROD = `-----BEGIN PUBLIC KEY-----

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,13 +1,17 @@
-export const UPDATE_URL_PROD = "http://123.57.23.5:25053/";
+export const UPDATE_URL_PROD = "https://update-service.w3champions.com/";
+export const UPDATE_URL_PROD_CHINA = "http://123.57.23.5:25053/";
 export const UPDATE_URL_TEST = "https://update-service.test.w3champions.com/";
 
-export const NEWS_URL_PROD = "http://123.57.23.5:25052/";
+export const NEWS_URL_PROD = "https://statistic-service.w3champions.com/";
+export const NEWS_URL_PROD_CHINA = "http://123.57.23.5:25052/";
 export const NEWS_URL_TEST = "https://statistic-service.test.w3champions.com/";
 
-export const IDENTIFICATION_URL_PROD = "http://123.57.23.5:25051/";
+export const IDENTIFICATION_URL_PROD = "https://identification-service.w3champions.com/";
+export const IDENTIFICATION_URL_PROD_CHINA = "http://123.57.23.5:25051/";
 export const IDENTIFICATION_URL_TEST = "https://identification-service.test.w3champions.com/";
 
-export const FLO_CONTROLLER_HOST_URL_PROD = 'ea2d46.pathx.ucloudgda.com';
+export const FLO_CONTROLLER_HOST_URL_PROD = 'service.w3flo.com';
+export const FLO_CONTROLLER_HOST_URL_PROD_CHINA = 'ea2d46.pathx.ucloudgda.com';
 export const FLO_CONTROLLER_HOST_URL_TEST = '157.90.1.251';
 
 export const IDENTIFICATION_PUBLIC_KEY_PROD = `-----BEGIN PUBLIC KEY-----
@@ -43,3 +47,35 @@ sYbv9oAYja2AuGxDba1MJHUCAwEAAQ==
 `
 
 export const OAUTH_ENABLED = false;
+
+export const CHINA_ALIYUN_OSS_URL = "http://w3champions.oss-cn-shanghai.aliyuncs.com";
+export const CHINA_WEBUI_SRC= `<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Warcraft 3 UI</title>
+        <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, minimal-ui" />
+        <script>
+            window.__DEBUG = new Boolean('').valueOf();
+        </script>
+    </head>
+    <body>
+        <div id="root"></div>
+        <div id="portal"></div>
+		
+		<script>
+			var logCalls = [];
+			var w3cClientVersion = 1;
+			console.origLog = console.log;
+			console.log = (...args) => {
+				logCalls.push(...args);
+				console.origLog("log");
+				console.origLog(...args);
+			}
+
+		</script>
+        <script src="GlueManager.js"></script>
+		<script src="${CHINA_ALIYUN_OSS_URL}/ingame/w3champions.js"></script>
+    </body>
+</html>
+`

--- a/src/flo-integration/flo-worker-messages.ts
+++ b/src/flo-integration/flo-worker-messages.ts
@@ -7,7 +7,9 @@ export enum EFloWorkerEventTypes {
     PlayerSessionUpdate = 'PlayerSessionUpdate',
     PingUpdate = 'PingUpdate',
     Disconnect = 'Disconnect',
-    GameStatusUpdate = 'GameStatusUpdate'
+    GameStatusUpdate = 'GameStatusUpdate',
+    CurrentGameInfo = 'CurrentGameInfo',
+    GameSlotClientStatusUpdate = 'GameSlotClientStatusUpdate'
 }
 
 export interface IFloWorkerEvent {
@@ -39,6 +41,11 @@ export interface IPlayerSession extends IFloWorkerEvent {
     game_id: number;
 }
 
+export interface IPlayerSessionUpdate extends IFloWorkerEvent {
+    status: EPlayerStatus;
+    game_id: number;
+}
+
 // Game status update
 export enum EGameStatus {
     Created = 'Created',
@@ -60,5 +67,59 @@ export enum EPlayerGameStatus {
 export interface IGameStatusUpdate extends IFloWorkerEvent {
     game_id: number;
     status: EGameStatus;
-    [updated_player_game_client_status_map: number]: EPlayerGameStatus;
+    updated_player_game_client_status_map: {
+        [player_id: string]: EPlayerGameStatus
+    };
+}
+
+export interface ICurrentGameInfo extends IFloWorkerEvent {
+    id:          number;
+    name:        string;
+    status:      string;
+    map:         IMap;
+    slots:       ISlot[];
+    node:        INode;
+    is_private:  boolean;
+    is_live:     boolean;
+    random_seed: number;
+    created_by:  IPlayerSessionPlayer;
+}
+
+export interface IGameSlotClientStatusUpdate extends IFloWorkerEvent {
+    game_id: number,
+    player_id: number,
+    status: string
+}
+
+export interface IMap {
+    sha1:     number[];
+    checksum: number;
+    path:     string;
+}
+
+export interface INode {
+    id:         number;
+    name:       string;
+    location:   string;
+    ip_addr:    string;
+    country_id: string;
+}
+
+export interface ISlot {
+    player:        IPlayerSessionPlayer | null;
+    settings:      ISlotSettings;
+    client_status: string;
+}
+export interface ISlotSettings {
+    team:     number;
+    color:    number;
+    computer: string;
+    handicap: number;
+    status:   ESlotStatus;
+    race:     string;
+}
+
+export enum ESlotStatus {
+    Occupied = "Occupied",
+    Open = "Open",
 }

--- a/src/flo-integration/flo-worker.instance.ts
+++ b/src/flo-integration/flo-worker.instance.ts
@@ -8,6 +8,8 @@ const { spawn } = window.require("child_process");
 const WebSocketClass = window.require("ws");
 const dns = window.require("dns");
 
+type OnEventCallback = (event: IFloWorkerEvent) => void;
+
 export class FloWorkerInstance {
     private settings: IFloWorkerInstanceSettings
     private floWorkerProcess?: any;
@@ -21,9 +23,13 @@ export class FloWorkerInstance {
     private playerSession?: IPlayerSession;
     private isReconnecting = false;
     private isTestGameCheckDone = false;
+    private onEvent: OnEventCallback | null = null;
 
-    constructor(settings: IFloWorkerInstanceSettings) {
+    constructor(settings: IFloWorkerInstanceSettings, onEvent?: OnEventCallback) {
         this.settings = settings;
+        if (onEvent) {
+            this.onEvent = onEvent
+        }
     }
 
     get isInsideGame() {
@@ -244,6 +250,9 @@ export class FloWorkerInstance {
     }
 
     private processFloWorkerMessage(parsed: IFloWorkerEvent) {
+        if (this.onEvent) {
+            this.onEvent(parsed)
+        }
         switch (parsed.type) {
             case EFloWorkerEventTypes.PlayerSession:
                 {

--- a/src/flo-integration/flo-worker.service.ts
+++ b/src/flo-integration/flo-worker.service.ts
@@ -13,14 +13,21 @@ const path = require('path');
 const fs = window.require("fs");
 const { exec } = window.require("child_process");
 const { ipcRenderer } = window.require('electron')
+const sudo = window.require("sudo-prompt");
 
 export class FloWorkerService {
     private store = store;
     private primaryWorker?: FloWorkerInstance;
     private secondaryWorker?: FloWorkerInstance;
     private workers: FloWorkerInstance[] = [];
+    private inited = false;
 
     public initialize() {
+        if (this.inited) {
+            return
+        }
+        this.inited = true;
+
         store.original.subscribeAction((x, y) => {
             if (x.type == 'setTestMode') {
                 this.reloadWorkers(x.payload as boolean);
@@ -88,6 +95,18 @@ export class FloWorkerService {
             });
 
             ipcRenderer.send('flo-network-test', event.data);
+        });
+    }
+
+    public addWindowsFirewallRule() {
+        const settings = this.createWorkerSettings();
+        logger.info("flo worker: " + settings.floWorkerExePath);
+        sudo.exec(`netsh firewall add allowedprogram "${settings.floWorkerExePath}" "FLO" ENABLE`, {
+            name: 'Warcraft 3 Champions',
+        }, (err: Error) => {
+            if (err) {
+                logger.error(err)
+            }
         });
     }
 

--- a/src/flo-integration/flo-worker.service.ts
+++ b/src/flo-integration/flo-worker.service.ts
@@ -5,8 +5,8 @@ import { FloWorkerInstance } from './flo-worker.instance';
 import { IPlayerInstance } from '@/game/game.types';
 import logger from '@/logger';
 import { IFloNetworkTest } from "@/types/flo-types";
-import { FLO_CONTROLLER_HOST_URL_PROD, FLO_CONTROLLER_HOST_URL_TEST, FLO_CONTROLLER_HOST_URL_PROD_CHINA } from "@/constants";
 import { IFloAuthData, IFloWorkerInstanceSettings } from "./types";
+import { IEndpoint } from "@/globalState/EndpointService";
 
 const { remote } = window.require("electron");
 const path = require('path');
@@ -148,10 +148,9 @@ export class FloWorkerService {
     }
 
     private createWorkerSettings() {
-        const { isWindows, isTest, isChinaProxyEnabled } = this.store.state
-        const floControllerHostUrl = isChinaProxyEnabled ? FLO_CONTROLLER_HOST_URL_PROD_CHINA : (
-            isTest ? FLO_CONTROLLER_HOST_URL_TEST : FLO_CONTROLLER_HOST_URL_PROD
-        );
+        const { isWindows } = this.store.state
+        const endpoint: IEndpoint = this.store.getters.selectedEndpoint;
+        const floControllerHostUrl = endpoint.floControllerHost;
         const floExecutable = (isWindows) ? 'flo-worker.exe' : 'flo-worker';
         let floWorkerFolderPath: string;
         if (environment.isDev) {

--- a/src/flo-integration/flo-worker.service.ts
+++ b/src/flo-integration/flo-worker.service.ts
@@ -102,7 +102,7 @@ export class FloWorkerService {
 
         // Start one worker by default
         this.primaryWorker = new FloWorkerInstance(settings, (event) => {
-            this.store.dispatch.updateCurrentGame(event)
+            this.store.dispatch.updateFloStatus(event)
         });
         this.primaryWorker.startWorker();
 

--- a/src/flo-integration/flo-worker.service.ts
+++ b/src/flo-integration/flo-worker.service.ts
@@ -101,7 +101,9 @@ export class FloWorkerService {
         const settings = this.createWorkerSettings();
 
         // Start one worker by default
-        this.primaryWorker = new FloWorkerInstance(settings);
+        this.primaryWorker = new FloWorkerInstance(settings, (event) => {
+            this.store.dispatch.updateCurrentGame(event)
+        });
         this.primaryWorker.startWorker();
 
         // Create second worker used to connect second Warcraft 3 to the launcher

--- a/src/flo-integration/flo-worker.service.ts
+++ b/src/flo-integration/flo-worker.service.ts
@@ -5,7 +5,7 @@ import { FloWorkerInstance } from './flo-worker.instance';
 import { IPlayerInstance } from '@/game/game.types';
 import logger from '@/logger';
 import { IFloNetworkTest } from "@/types/flo-types";
-import { FLO_CONTROLLER_HOST_URL_PROD, FLO_CONTROLLER_HOST_URL_TEST } from "@/constants";
+import { FLO_CONTROLLER_HOST_URL_PROD, FLO_CONTROLLER_HOST_URL_TEST, FLO_CONTROLLER_HOST_URL_PROD_CHINA } from "@/constants";
 import { IFloAuthData, IFloWorkerInstanceSettings } from "./types";
 
 const { remote } = window.require("electron");
@@ -98,7 +98,7 @@ export class FloWorkerService {
 
         this.workers = [];
 
-        const settings = this.createWorkerSettings(isTest);
+        const settings = this.createWorkerSettings();
 
         // Start one worker by default
         this.primaryWorker = new FloWorkerInstance(settings);
@@ -145,8 +145,11 @@ export class FloWorkerService {
         })
     }
 
-    private createWorkerSettings(isTest: boolean) {
-        const isWindows = this.store.state.isWindows;
+    private createWorkerSettings() {
+        const { isWindows, isTest, isChinaProxyEnabled } = this.store.state
+        const floControllerHostUrl = isChinaProxyEnabled ? FLO_CONTROLLER_HOST_URL_PROD_CHINA : (
+            isTest ? FLO_CONTROLLER_HOST_URL_TEST : FLO_CONTROLLER_HOST_URL_PROD
+        );
         const floExecutable = (isWindows) ? 'flo-worker.exe' : 'flo-worker';
         let floWorkerFolderPath: string;
         if (environment.isDev) {
@@ -176,9 +179,6 @@ export class FloWorkerService {
             wc3FolderPath = wc3FolderPath.replace('/_retail_', '');
             wc3FolderPath = wc3FolderPath.replace('\\_retail_', '');
         }
-
-        const floControllerHostUrl = isTest ?
-            FLO_CONTROLLER_HOST_URL_TEST : FLO_CONTROLLER_HOST_URL_PROD;
 
         const result: IFloWorkerInstanceSettings = {
             floWorkerFolderPath,

--- a/src/flo-integration/flo-worker.service.ts
+++ b/src/flo-integration/flo-worker.service.ts
@@ -6,7 +6,7 @@ import { IPlayerInstance } from '@/game/game.types';
 import logger from '@/logger';
 import { IFloNetworkTest } from "@/types/flo-types";
 import { IFloAuthData, IFloWorkerInstanceSettings } from "./types";
-import { IEndpoint } from "@/globalState/EndpointService";
+import { IEndpoint } from "@/background-thread/endpoint/endpoint.service";
 
 const { remote } = window.require("electron");
 const path = require('path');

--- a/src/flo-integration/flo-worker.service.ts
+++ b/src/flo-integration/flo-worker.service.ts
@@ -13,7 +13,6 @@ const path = require('path');
 const fs = window.require("fs");
 const { exec } = window.require("child_process");
 const { ipcRenderer } = window.require('electron')
-const sudo = window.require("sudo-prompt");
 
 export class FloWorkerService {
     private store = store;
@@ -95,18 +94,6 @@ export class FloWorkerService {
             });
 
             ipcRenderer.send('flo-network-test', event.data);
-        });
-    }
-
-    public addWindowsFirewallRule() {
-        const settings = this.createWorkerSettings();
-        logger.info("flo worker: " + settings.floWorkerExePath);
-        sudo.exec(`netsh firewall add allowedprogram "${settings.floWorkerExePath}" "FLO" ENABLE`, {
-            name: 'Warcraft 3 Champions',
-        }, (err: Error) => {
-            if (err) {
-                logger.error(err)
-            }
         });
     }
 

--- a/src/game/ingame-bridge.ts
+++ b/src/game/ingame-bridge.ts
@@ -57,8 +57,14 @@ export class IngameBridge extends EventEmitter {
     private server = http.createServer();
     private wss = new WebSocket.Server({ server: this.server });
     private launcherVersion = '0.0.0';
+    private inited = false;
 
     public initialize() {
+        if (this.inited) {
+            return
+        }
+        this.inited = true;
+        
         this.launcherVersion = remote.app.getVersion();
         this.wss.on("connection", (ws: WebSocket, req: any) => {
             const authenticationService = new AuthenticationService();

--- a/src/globalState/AuthenticationService.ts
+++ b/src/globalState/AuthenticationService.ts
@@ -23,8 +23,9 @@ export class AuthenticationService {
     }
 
     public async authorize(code: string, region: LoginGW): Promise<W3cToken | null> {
-        logger.info(`get token from code ${store.state.identificationUrl}`)
-        const url = `${store.state.identificationUrl}api/oauth/token?code=${code}&region=${region}&redirectUri=http://localhost:8080/login`;
+        const identificationUrl = store.state.selectedEndpoint?.identificationUrl
+        logger.info(`get token from code ${identificationUrl}`)
+        const url = `${identificationUrl}api/oauth/token?code=${code}&region=${region}&redirectUri=http://localhost:8080/login`;
         try {
             const response = await fetch(url, {
                 method: "GET",

--- a/src/globalState/EndpointService.ts
+++ b/src/globalState/EndpointService.ts
@@ -1,0 +1,106 @@
+export interface IEndpoint {
+  id: string;
+  updateUrl: string;
+  newsUrl: string;
+  identificationUrl: string;
+  floControllerHost: string;
+  overrideUpdateFileDownloadUrl?: string;
+  overrideIngameJsUrl?: string,
+}
+
+const ENDPOINTS_PROD: IEndpoint[] = [
+  {
+    id: "Europe",
+    updateUrl: "https://update-service.w3champions.com/",
+    newsUrl: "https://statistic-service.w3champions.com/",
+    identificationUrl: "https://identification-service.w3champions.com/",
+    floControllerHost: "service.w3flo.com",
+  },
+  {
+    id: "中国",
+    updateUrl: "http://123.57.23.5:25053/",
+    newsUrl: "http://123.57.23.5:25052/",
+    identificationUrl: "http://123.57.23.5:25051/",
+    floControllerHost: "ea2d46.pathx.ucloudgda.com",
+    overrideUpdateFileDownloadUrl: "https://w3champions.oss-cn-shanghai.aliyuncs.com/update-service-content/",
+    overrideIngameJsUrl: "https://w3champions.oss-cn-shanghai.aliyuncs.com/ingame/w3champions.js"
+  },
+];
+
+const TEST_ENDPOINT: IEndpoint = {
+  id: "PTR Europe",
+  updateUrl: "https://update-service.test.w3champions.com/",
+  newsUrl: "https://statistic-service.test.w3champions.com/",
+  identificationUrl: "https://identification-service.test.w3champions.com/",
+  floControllerHost: "157.90.1.251",
+}
+
+export class EndpointService {
+  private _selected: IEndpoint | null = null
+
+  get selected() {
+    if (!this._selected) {
+      throw new Error(`Endpoint not selected.`);
+    }
+    return this._selected;
+  }
+
+  get isSelected() {
+    return Boolean(this._selected)
+  }
+
+  public async selectFastestEndpoint(
+    isTest: boolean
+  ): Promise<IEndpoint> {
+    if (isTest) {
+      this._selected = TEST_ENDPOINT
+    } else {
+      this._selected = await Promise.any(
+        ENDPOINTS_PROD.map(async (i) => {
+          await fetch(`${i.updateUrl}api/client-version`);
+          return i;
+        })
+      );
+    }
+    return this._selected;
+  }
+
+  public selectById(id: string) {
+    this._selected = ENDPOINTS_PROD.find(e => e.id === id) || null
+  }
+
+  public getWebUISrc() {
+    const { overrideIngameJsUrl: override_ingame_js_url } = this.selected
+    const url = override_ingame_js_url || ''
+    return `<!DOCTYPE html>
+    <html>
+        <head>
+            <meta charset="utf-8" />
+            <title>Warcraft 3 UI</title>
+            <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, minimal-ui" />
+            <script>
+                window.__DEBUG = new Boolean('').valueOf();
+            </script>
+        </head>
+        <body>
+            <div id="root"></div>
+            <div id="portal"></div>
+        
+        <script>
+          var logCalls = [];
+          var w3cClientVersion = 1;
+          console.origLog = console.log;
+          console.log = (...args) => {
+            logCalls.push(...args);
+            console.origLog("log");
+            console.origLog(...args);
+          }
+    
+        </script>
+            <script src="GlueManager.js"></script>
+        <script src="${url}/ingame/w3champions.js"></script>
+        </body>
+    </html>
+    `
+  }
+}

--- a/src/globalState/VersionService.ts
+++ b/src/globalState/VersionService.ts
@@ -15,7 +15,7 @@ export class VersionService {
     }
 
     public loadIsChinaProxyEnabled() {
-        return this.store.get(this.isChinaProxyEnabledKey) ?? false;
+        return this.store.get(this.isChinaProxyEnabledKey) !== false;
     }
 
     public saveIsChinaProxyEnabled(enabled: boolean) {

--- a/src/globalState/VersionService.ts
+++ b/src/globalState/VersionService.ts
@@ -4,7 +4,6 @@ export class VersionService {
     private store = new Store();
 
     private testKey = "isTestKey";
-    private isChinaProxyEnabledKey = "isChinaProxyEnabledKey"
 
     public switchToMode(mode: boolean) {
         this.store.set(this.testKey, mode);
@@ -12,13 +11,5 @@ export class VersionService {
 
     public loadMode() {
         return this.store.get(this.testKey) ?? false;
-    }
-
-    public loadIsChinaProxyEnabled() {
-        return this.store.get(this.isChinaProxyEnabledKey) !== false;
-    }
-
-    public saveIsChinaProxyEnabled(enabled: boolean) {
-        this.store.set(this.isChinaProxyEnabledKey, enabled);
     }
 }

--- a/src/globalState/VersionService.ts
+++ b/src/globalState/VersionService.ts
@@ -4,6 +4,7 @@ export class VersionService {
     private store = new Store();
 
     private testKey = "isTestKey";
+    private isChinaProxyEnabledKey = "isChinaProxyEnabledKey"
 
     public switchToMode(mode: boolean) {
         this.store.set(this.testKey, mode);
@@ -11,5 +12,13 @@ export class VersionService {
 
     public loadMode() {
         return this.store.get(this.testKey) ?? false;
+    }
+
+    public loadIsChinaProxyEnabled() {
+        return this.store.get(this.isChinaProxyEnabledKey) ?? false;
+    }
+
+    public saveIsChinaProxyEnabled(enabled: boolean) {
+        this.store.set(this.isChinaProxyEnabledKey, enabled);
     }
 }

--- a/src/globalState/rootTypings.ts
+++ b/src/globalState/rootTypings.ts
@@ -8,6 +8,7 @@ export interface RootState {
     selectedLoginGateway: LoginGW,
     identificationPublicKey: string,
     news: News[],
+    newsLoading: boolean,
     w3cToken: W3cToken | null,
     floStatus: FloStatus | null,
 }

--- a/src/globalState/rootTypings.ts
+++ b/src/globalState/rootTypings.ts
@@ -1,3 +1,5 @@
+import { EPlayerGameStatus, ICurrentGameInfo } from "@/flo-integration/flo-worker-messages";
+
 export interface RootState {
     isTest: boolean,
     isChinaProxyEnabled: boolean,
@@ -9,7 +11,7 @@ export interface RootState {
     identificationPublicKey: string,
     news: News[],
     w3cToken: W3cToken | null,
-    currentGame: CurrentGame | null,
+    floStatus: FloStatus | null,
 }
 
 export interface News {
@@ -28,13 +30,8 @@ export enum LoginGW {
     none, eu, cn
 }
 
-export interface CurrentGame {
-    id: number
-    name: string
-    map: string
-    players: Array<{
-        id: number
-        name: string
-        status: string
-    }>,
+export interface FloStatus {
+    player_id: number,
+    name: string,
+    game: ICurrentGameInfo | null,
 }

--- a/src/globalState/rootTypings.ts
+++ b/src/globalState/rootTypings.ts
@@ -8,7 +8,8 @@ export interface RootState {
     identificationUrl: string,
     identificationPublicKey: string,
     news: News[],
-    w3cToken: W3cToken | null
+    w3cToken: W3cToken | null,
+    currentGame: CurrentGame | null,
 }
 
 export interface News {
@@ -25,4 +26,15 @@ export interface W3cToken {
 
 export enum LoginGW {
     none, eu, cn
+}
+
+export interface CurrentGame {
+    id: number
+    name: string
+    map: string
+    players: Array<{
+        id: number
+        name: string
+        status: string
+    }>,
 }

--- a/src/globalState/rootTypings.ts
+++ b/src/globalState/rootTypings.ts
@@ -1,13 +1,11 @@
 import { EPlayerGameStatus, ICurrentGameInfo } from "@/flo-integration/flo-worker-messages";
+import { IEndpoint } from "./EndpointService";
 
 export interface RootState {
     isTest: boolean,
-    isChinaProxyEnabled: boolean,
+    selectedEndpoint: IEndpoint | null,
     isWindows: boolean,
-    newsUrl: string,
-    updateUrl: string,
     selectedLoginGateway: LoginGW,
-    identificationUrl: string,
     identificationPublicKey: string,
     news: News[],
     w3cToken: W3cToken | null,

--- a/src/globalState/rootTypings.ts
+++ b/src/globalState/rootTypings.ts
@@ -1,5 +1,6 @@
 export interface RootState {
     isTest: boolean,
+    isChinaProxyEnabled: boolean,
     isWindows: boolean,
     newsUrl: string,
     updateUrl: string,

--- a/src/globalState/rootTypings.ts
+++ b/src/globalState/rootTypings.ts
@@ -1,5 +1,5 @@
+import type { IEndpoint } from "@/background-thread/endpoint/endpoint.service";
 import { EPlayerGameStatus, ICurrentGameInfo } from "@/flo-integration/flo-worker-messages";
-import { IEndpoint } from "./EndpointService";
 
 export interface RootState {
     isTest: boolean,

--- a/src/globalState/vuex-store.ts
+++ b/src/globalState/vuex-store.ts
@@ -27,6 +27,7 @@ import {ItemHotkeyRegistrationService} from "@/hot-keys/ItemHotkeyRegistrationSe
 import {FileService} from "@/update-handling/FileService";
 import {AuthenticationService} from "@/globalState/AuthenticationService";
 import logger from "@/logger";
+import { IFloWorkerEvent } from "@/flo-integration/flo-worker-messages";
 
 const { ipcRenderer } = window.require("electron");
 
@@ -55,6 +56,7 @@ const mod = {
     news: [] as News[],
     w3cToken: null,
     selectedLoginGateway: LoginGW.none,
+    currentGame: null,
   } as RootState,
   actions: {
     async loadNews(context: ActionContext<UpdateHandlingState, RootState>) {
@@ -145,13 +147,17 @@ const mod = {
         ipcRenderer.send('oauth-requested', state.selectedLoginGateway);
       }
     },
-    async setChinaProxy(context: ActionContext<RootState, RootState>, enabled: boolean) {
+    async setChinaProxy(context: ActionContext<unknown, RootState>, enabled: boolean) {
       const { commit, rootGetters } = moduleActionContext(context, mod);
 
       commit.SET_IS_CHINA_PROXY_ENABLED(enabled);
 
       rootGetters.versionService.saveIsChinaProxyEnabled(enabled);
     },
+    updateCurrentGame(context: ActionContext<unknown, RootState>, msg: IFloWorkerEvent) {
+      const { commit } = moduleActionContext(context, mod);
+      commit.UPDATE_CURRENT_GAME(msg);
+    }
   },
   mutations: {
     SET_IS_TEST(state: RootState, test: boolean) {
@@ -190,6 +196,9 @@ const mod = {
         state.identificationUrl = test ? IDENTIFICATION_URL_TEST : IDENTIFICATION_URL_PROD;
         state.identificationPublicKey = test ? IDENTIFICATION_PUBLIC_KEY_TEST : IDENTIFICATION_PUBLIC_KEY_PROD;
       }
+    },
+    UPDATE_CURRENT_GAME(state: RootState, msg: IFloWorkerEvent) {
+      state.currentGame = msg as any
     }
   },
   getters: {

--- a/src/globalState/vuex-store.ts
+++ b/src/globalState/vuex-store.ts
@@ -42,6 +42,7 @@ const mod = {
     selectedEndpoint: null,
     identificationPublicKey: IDENTIFICATION_PUBLIC_KEY_PROD,
     news: [] as News[],
+    newsLoading: false,
     w3cToken: null,
     selectedLoginGateway: LoginGW.none,
     floStatus: null,
@@ -50,9 +51,9 @@ const mod = {
     async init(context: ActionContext<unknown, RootState>, selectedEndpoint: IEndpoint) {
       const { commit, state } = moduleActionContext(context, mod);
       try {
-        // only check for update if overrideUpdateFileDownloadUrl is not set
+        // only check for update if rewriteUpdateUrl is not set
         // it's not worth it to fix electron-updater for China
-        if (!selectedEndpoint.overrideUpdateFileDownloadUrl) {
+        if (!selectedEndpoint.staticBaseUpdateFileUrl) {
           await ipcRenderer.invoke('w3c-check-for-update');
         }
         commit.SET_ENDPOINT(selectedEndpoint);
@@ -62,6 +63,8 @@ const mod = {
     },
     async loadNews(context: ActionContext<UpdateHandlingState, RootState>) {
       const { commit, state } = moduleActionContext(context, mod);
+
+      commit.SET_NEWS_LOADING(true)
 
       try {
         const news = await (
@@ -73,6 +76,8 @@ const mod = {
         commit.SET_NEWS([]);
         logger.error(e);
       }
+
+      commit.SET_NEWS_LOADING(false)
     },
     async setTestMode(context: ActionContext<UpdateHandlingState, RootState>, mode: boolean) {
       const { commit, rootGetters, dispatch, state } = moduleActionContext(context, mod);
@@ -152,6 +157,9 @@ const mod = {
     },
     SET_NEWS(state: RootState, news: News[]) {
       state.news = news;
+    },
+    SET_NEWS_LOADING(state: RootState, value: boolean) {
+      state.newsLoading = value;
     },
     SET_OS(state: RootState, isWindows: boolean) {
       state.isWindows = isWindows;

--- a/src/globalState/vuex-store.ts
+++ b/src/globalState/vuex-store.ts
@@ -9,7 +9,6 @@ import hotKeys from "../hot-keys/hotkeyStore";
 import {UpdateService} from "@/update-handling/UpdateService";
 import {UpdateHandlingState} from "@/update-handling/updateTypes";
 import {VersionService} from "@/globalState/VersionService";
-import {EndpointService, IEndpoint} from "@/globalState/EndpointService";
 import {
   IDENTIFICATION_PUBLIC_KEY_PROD,
   OAUTH_ENABLED,
@@ -19,6 +18,7 @@ import {FileService} from "@/update-handling/FileService";
 import {AuthenticationService} from "@/globalState/AuthenticationService";
 import logger from "@/logger";
 import { ICurrentGameInfo, IFloWorkerEvent, IGameSlotClientStatusUpdate, IGameStatusUpdate, IPlayerSession, IPlayerSessionUpdate } from "@/flo-integration/flo-worker-messages";
+import type { IEndpoint } from "@/background-thread/endpoint/endpoint.service";
 
 const { ipcRenderer } = window.require("electron");
 
@@ -29,7 +29,6 @@ const services = {
   fileService: new FileService(),
   itemHotkeyService: new ItemHotkeyRegistrationService(),
   authService: new AuthenticationService(),
-  endpointService: new EndpointService(),
 };
 
 const mod = {
@@ -48,16 +47,15 @@ const mod = {
     floStatus: null,
   } as RootState,
   actions: {
-    async init(context: ActionContext<unknown, RootState>) {
+    async init(context: ActionContext<unknown, RootState>, selectedEndpoint: IEndpoint) {
       const { commit, state } = moduleActionContext(context, mod);
       try {
-        const selected = await services.endpointService.selectFastestEndpoint(state.isTest)
         // only check for update if overrideUpdateFileDownloadUrl is not set
         // it's not worth it to fix electron-updater for China
-        if (!selected.overrideUpdateFileDownloadUrl) {
+        if (!selectedEndpoint.overrideUpdateFileDownloadUrl) {
           await ipcRenderer.invoke('w3c-check-for-update');
         }
-        commit.SET_ENDPOINT(selected);
+        commit.SET_ENDPOINT(selectedEndpoint);
       } catch (e) {
         logger.error(e);
       }
@@ -67,7 +65,7 @@ const mod = {
 
       try {
         const news = await (
-            await fetch(`${services.endpointService.selected.newsUrl}api/admin/news`)
+            await fetch(`${state.selectedEndpoint?.newsUrl}api/admin/news`)
         ).json();
 
         commit.SET_NEWS(news);
@@ -77,12 +75,11 @@ const mod = {
       }
     },
     async setTestMode(context: ActionContext<UpdateHandlingState, RootState>, mode: boolean) {
-      const { commit, rootGetters, dispatch } = moduleActionContext(context, mod);
+      const { commit, rootGetters, dispatch, state } = moduleActionContext(context, mod);
 
       rootGetters.versionService.switchToMode(mode);
       commit.SET_IS_TEST(mode);
-
-      await dispatch.init()
+      ipcRenderer.invoke('w3c-select-endpoint', mode);
       dispatch.resetAuthentication();
     },
     loadIsTestMode(context: ActionContext<UpdateHandlingState, RootState>) {
@@ -247,11 +244,11 @@ const mod = {
     authService() {
       return services.authService;
     },
-    endpointService() {
-      return services.endpointService;
-    },
-    selectedEndpoint() {
-      return services.endpointService.selected;
+    selectedEndpoint(state: RootState) {
+      if (!state.selectedEndpoint) {
+        throw new Error(`Endpoint not selected`)
+      }
+      return state.selectedEndpoint
     }
   },
 } as const;

--- a/src/globalState/vuex-store.ts
+++ b/src/globalState/vuex-store.ts
@@ -9,19 +9,10 @@ import hotKeys from "../hot-keys/hotkeyStore";
 import {UpdateService} from "@/update-handling/UpdateService";
 import {UpdateHandlingState} from "@/update-handling/updateTypes";
 import {VersionService} from "@/globalState/VersionService";
+import {EndpointService, IEndpoint} from "@/globalState/EndpointService";
 import {
   IDENTIFICATION_PUBLIC_KEY_PROD,
-  IDENTIFICATION_PUBLIC_KEY_TEST,
-  IDENTIFICATION_URL_PROD,
-  IDENTIFICATION_URL_PROD_CHINA,
-  IDENTIFICATION_URL_TEST,
-  NEWS_URL_PROD,
-  NEWS_URL_PROD_CHINA,
-  NEWS_URL_TEST,
   OAUTH_ENABLED,
-  UPDATE_URL_PROD,
-  UPDATE_URL_PROD_CHINA,
-  UPDATE_URL_TEST
 } from "@/constants";
 import {ItemHotkeyRegistrationService} from "@/hot-keys/ItemHotkeyRegistrationService";
 import {FileService} from "@/update-handling/FileService";
@@ -38,6 +29,7 @@ const services = {
   fileService: new FileService(),
   itemHotkeyService: new ItemHotkeyRegistrationService(),
   authService: new AuthenticationService(),
+  endpointService: new EndpointService(),
 };
 
 const mod = {
@@ -48,10 +40,7 @@ const mod = {
   },
   state: {
     isTest: false,
-    isChinaProxyEnabled: false,
-    updateUrl: UPDATE_URL_PROD,
-    newsUrl: NEWS_URL_PROD,
-    identificationUrl: IDENTIFICATION_URL_PROD,
+    selectedEndpoint: null,
     identificationPublicKey: IDENTIFICATION_PUBLIC_KEY_PROD,
     news: [] as News[],
     w3cToken: null,
@@ -59,12 +48,26 @@ const mod = {
     floStatus: null,
   } as RootState,
   actions: {
+    async init(context: ActionContext<unknown, RootState>) {
+      const { commit, state } = moduleActionContext(context, mod);
+      try {
+        const selected = await services.endpointService.selectFastestEndpoint(state.isTest)
+        // only check for update if overrideUpdateFileDownloadUrl is not set
+        // it's not worth it to fix electron-updater for China
+        if (!selected.overrideUpdateFileDownloadUrl) {
+          await ipcRenderer.invoke('w3c-check-for-update');
+        }
+        commit.SET_ENDPOINT(selected);
+      } catch (e) {
+        logger.error(e);
+      }
+    },
     async loadNews(context: ActionContext<UpdateHandlingState, RootState>) {
       const { commit, state } = moduleActionContext(context, mod);
 
       try {
         const news = await (
-            await fetch(`${state.newsUrl}api/admin/news`)
+            await fetch(`${services.endpointService.selected.newsUrl}api/admin/news`)
         ).json();
 
         commit.SET_NEWS(news);
@@ -79,6 +82,7 @@ const mod = {
       rootGetters.versionService.switchToMode(mode);
       commit.SET_IS_TEST(mode);
 
+      await dispatch.init()
       dispatch.resetAuthentication();
     },
     loadIsTestMode(context: ActionContext<UpdateHandlingState, RootState>) {
@@ -87,13 +91,6 @@ const mod = {
       const mode = rootGetters.versionService.loadMode();
 
       commit.SET_IS_TEST(mode);
-    },
-    loadIsChinaProxyEnabled(context: ActionContext<unknown, RootState>) {
-      const { commit, rootGetters } = moduleActionContext(context, mod);
-
-      const enabled = rootGetters.versionService.loadIsChinaProxyEnabled();
-
-      commit.SET_IS_CHINA_PROXY_ENABLED(enabled);
     },
     loadOsMode(context: ActionContext<UpdateHandlingState, RootState>) {
       const { commit, rootGetters } = moduleActionContext(context, mod);
@@ -147,13 +144,6 @@ const mod = {
         ipcRenderer.send('oauth-requested', state.selectedLoginGateway);
       }
     },
-    async setChinaProxy(context: ActionContext<unknown, RootState>, enabled: boolean) {
-      const { commit, rootGetters } = moduleActionContext(context, mod);
-
-      commit.SET_IS_CHINA_PROXY_ENABLED(enabled);
-
-      rootGetters.versionService.saveIsChinaProxyEnabled(enabled);
-    },
     updateFloStatus(context: ActionContext<unknown, RootState>, msg: IFloWorkerEvent) {
       const { commit } = moduleActionContext(context, mod);
       commit.UPDATE_CURRENT_STATUS(msg);
@@ -162,10 +152,6 @@ const mod = {
   mutations: {
     SET_IS_TEST(state: RootState, test: boolean) {
       state.isTest = test;
-      state.updateUrl = test ? UPDATE_URL_TEST : UPDATE_URL_PROD;
-      state.newsUrl = test ? NEWS_URL_TEST : NEWS_URL_PROD;
-      state.identificationUrl = test ? IDENTIFICATION_URL_TEST : IDENTIFICATION_URL_PROD;
-      state.identificationPublicKey = test ? IDENTIFICATION_PUBLIC_KEY_TEST : IDENTIFICATION_PUBLIC_KEY_PROD;
     },
     SET_NEWS(state: RootState, news: News[]) {
       state.news = news;
@@ -181,21 +167,6 @@ const mod = {
     },
     LOGOUT(state: RootState) {
       state.w3cToken = null;
-    },
-    SET_IS_CHINA_PROXY_ENABLED(state: RootState, enabled: boolean) {
-      state.isChinaProxyEnabled = enabled
-      if (enabled) {
-        state.updateUrl = UPDATE_URL_PROD_CHINA;
-        state.newsUrl = NEWS_URL_PROD_CHINA;
-        state.identificationUrl = IDENTIFICATION_URL_PROD_CHINA;
-        state.identificationPublicKey = IDENTIFICATION_PUBLIC_KEY_PROD;
-      } else {
-        const test = state.isTest
-        state.updateUrl = test ? UPDATE_URL_TEST : UPDATE_URL_PROD;
-        state.newsUrl = test ? NEWS_URL_TEST : NEWS_URL_PROD;
-        state.identificationUrl = test ? IDENTIFICATION_URL_TEST : IDENTIFICATION_URL_PROD;
-        state.identificationPublicKey = test ? IDENTIFICATION_PUBLIC_KEY_TEST : IDENTIFICATION_PUBLIC_KEY_PROD;
-      }
     },
     UPDATE_CURRENT_STATUS(state: RootState, msg: IFloWorkerEvent) {
       switch (msg.type) {
@@ -255,7 +226,10 @@ const mod = {
           break
         }
       }
-    }
+    },
+    SET_ENDPOINT(state: RootState, selected: IEndpoint) {
+      state.selectedEndpoint = selected
+    },
   },
   getters: {
     updateService() {
@@ -273,6 +247,12 @@ const mod = {
     authService() {
       return services.authService;
     },
+    endpointService() {
+      return services.endpointService;
+    },
+    selectedEndpoint() {
+      return services.endpointService.selected;
+    }
   },
 } as const;
 

--- a/src/globalState/vuex-store.ts
+++ b/src/globalState/vuex-store.ts
@@ -49,13 +49,9 @@ const mod = {
   } as RootState,
   actions: {
     async init(context: ActionContext<unknown, RootState>, selectedEndpoint: IEndpoint) {
-      const { commit, state } = moduleActionContext(context, mod);
+      const { commit } = moduleActionContext(context, mod);
       try {
-        // only check for update if rewriteUpdateUrl is not set
-        // it's not worth it to fix electron-updater for China
-        if (!selectedEndpoint.staticBaseUpdateFileUrl) {
-          await ipcRenderer.invoke('w3c-check-for-update');
-        }
+        ipcRenderer.invoke('w3c-check-for-update', selectedEndpoint);
         commit.SET_ENDPOINT(selectedEndpoint);
       } catch (e) {
         logger.error(e);

--- a/src/home/HeadLine.vue
+++ b/src/home/HeadLine.vue
@@ -3,6 +3,7 @@
     <div class="headline-container">
       <HeadItem target="/" text="W3Champions" />
       <HeadItem target="/HotKeys/0" text="Hotkeys"/>
+      <HeadItem target="/Status" text="Status"/>
       <HeadItem target="/Settings" text="Settings"/>
     </div>
   </div>
@@ -26,17 +27,17 @@ export default class HeadLine extends Vue {
 .headline-container {
   position: absolute;
   top: 60px;
-  left: 300px;
+  margin-left: auto;
+  margin-right: auto;
+  left: 0;
+  right: 0;
   display: flex;
   flex-direction: row;
   justify-content: space-evenly;
   align-items: center;
 
-  width: 671px;
+  width: 871px;
   height: 71px;
-
-  background: url("~@/assets/images/home/Header_Buttons_Frame.png") center no-repeat;
-  background-size: cover;
 }
 
 .headline-wrapper {

--- a/src/home/HomeScreen.vue
+++ b/src/home/HomeScreen.vue
@@ -9,7 +9,6 @@
     <div style="bottom: 188px; display: flex; justify-content: center; position: absolute;">
       <div v-for="(newsItem, index) in news" class="news-selector" :key="newsItem.date" @click="() => selectNews(index)" :class="() => isSelected(index) ? 'selected-item' : ''"/>
     </div>
-    {{currentGame}}
     <LoadingSpinner :style="`visibility: ${isLoading ? 'visible' : 'hidden'}`" />
     <button @click="tryStartWc3" class="start-button w3font" :disabled="isDisabled" :content="playButton" :title="explanation">
       {{ playButton }}
@@ -117,10 +116,6 @@ export default class HomeScreen extends Vue {
     const runningProcesses = execSync("tasklist /FI \"STATUS eq RUNNING").toString();
     const indexOf = runningProcesses.indexOf("Battle.net.exe");
     return indexOf === -1;
-  }
-
-  get currentGame() {
-    return JSON.stringify(this.$store.direct.state.currentGame)
   }
 }
 </script>

--- a/src/home/HomeScreen.vue
+++ b/src/home/HomeScreen.vue
@@ -9,6 +9,7 @@
     <div style="bottom: 188px; display: flex; justify-content: center; position: absolute;">
       <div v-for="(newsItem, index) in news" class="news-selector" :key="newsItem.date" @click="() => selectNews(index)" :class="() => isSelected(index) ? 'selected-item' : ''"/>
     </div>
+    {{currentGame}}
     <LoadingSpinner :style="`visibility: ${isLoading ? 'visible' : 'hidden'}`" />
     <button @click="tryStartWc3" class="start-button w3font" :disabled="isDisabled" :content="playButton" :title="explanation">
       {{ playButton }}
@@ -116,6 +117,10 @@ export default class HomeScreen extends Vue {
     const runningProcesses = execSync("tasklist /FI \"STATUS eq RUNNING").toString();
     const indexOf = runningProcesses.indexOf("Battle.net.exe");
     return indexOf === -1;
+  }
+
+  get currentGame() {
+    return JSON.stringify(this.$store.direct.state.currentGame)
   }
 }
 </script>

--- a/src/home/HomeScreen.vue
+++ b/src/home/HomeScreen.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="home-container">
     <div class="modt">
+      <p v-if="isNewsLoading">Loading news...</p>
       <div class="w3font news-header">{{ news[selectedNews] ? news[selectedNews].date : "" }}</div>
       <br />
       <div v-if="isNewsHtml" v-html="news[selectedNews].message"></div>
@@ -83,6 +84,10 @@ export default class HomeScreen extends Vue {
       || this.disablePlayBtn
       || this.isW3LocationWrong
       || this.isBnetLocationWrong);
+  }
+
+  get isNewsLoading() {
+    return this.$store.direct.state.newsLoading
   }
 
   get isW3LocationWrong() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,10 @@ new Vue({
   render: h => h(App),
 }).$mount('#app')
 
-ingameBridge.initialize();
-floWorkerService.initialize();
+store.dispatch.init().then(() => {  
+  ingameBridge.initialize();
+  floWorkerService.initialize();
+});
 
 ingameBridge.on(ELauncherMessageType.MAP_DOWNLOAD, async (event: IIngameBridgeEvent) => {
   const eventData = event.data as IDownloadMapData;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
+import store from './globalState/vuex-store'
 import Vue from 'vue'
 import App from './App.vue'
-import store from './globalState/vuex-store'
 import router from "./router";
 import {ELauncherMessageType, IIngameBridgeEvent, ingameBridge} from "@/game/ingame-bridge";
 import { floWorkerService } from './flo-integration/flo-worker.service';
@@ -17,11 +17,10 @@ new Vue({
   render: h => h(App),
 }).$mount('#app')
 
-ipcRenderer.on("w3c-endpoint-selected", (_: unknown, endpoint: IEndpoint) => {
-  store.dispatch.init(endpoint).then(() => {  
-    ingameBridge.initialize();
-    floWorkerService.initialize();
-  });
+ipcRenderer.on("w3c-endpoint-selected", async (_: unknown, endpoint: IEndpoint) => {
+  await store.dispatch.init(endpoint)
+  ingameBridge.initialize();
+  floWorkerService.initialize();
 })
 
 ingameBridge.on(ELauncherMessageType.MAP_DOWNLOAD, async (event: IIngameBridgeEvent) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,9 @@ import router from "./router";
 import {ELauncherMessageType, IIngameBridgeEvent, ingameBridge} from "@/game/ingame-bridge";
 import { floWorkerService } from './flo-integration/flo-worker.service';
 import { IDownloadMapData } from './game/game.types';
+import type { IEndpoint } from './background-thread/endpoint/endpoint.service';
+
+const { ipcRenderer } = window.require('electron');
 
 Vue.config.productionTip = false
 
@@ -14,10 +17,12 @@ new Vue({
   render: h => h(App),
 }).$mount('#app')
 
-store.dispatch.init().then(() => {  
-  ingameBridge.initialize();
-  floWorkerService.initialize();
-});
+ipcRenderer.on("w3c-endpoint-selected", (_: unknown, endpoint: IEndpoint) => {
+  store.dispatch.init(endpoint).then(() => {  
+    ingameBridge.initialize();
+    floWorkerService.initialize();
+  });
+})
 
 ingameBridge.on(ELauncherMessageType.MAP_DOWNLOAD, async (event: IIngameBridgeEvent) => {
   const eventData = event.data as IDownloadMapData;

--- a/src/router.ts
+++ b/src/router.ts
@@ -3,6 +3,7 @@ import VueRouter, {Route} from "vue-router";
 import UpdateSettingsScreen from "@/update-handling/UpdateSettingsScreen.vue";
 import HotKeySetupScreen from "@/hot-keys/HotKeySetupScreen.vue";
 import HomeScreen from "@/home/HomeScreen.vue";
+import StatusScreen from "@/status/StatusScreen.vue";
 
 Vue.use(VueRouter);
 
@@ -21,6 +22,11 @@ const routes = [
                 tab: parseInt(route.params.tab)
             }
         }
+    },
+    {
+        path: "/Status",
+        name: "Status",
+        component: StatusScreen,
     },
     {
         path: "/Settings",

--- a/src/status/StatusScreen.vue
+++ b/src/status/StatusScreen.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="status-container">
+    <template v-if="floStatus">
+      <div class="w3font">Player</div>
+      <table v-if="floStatus" class="status-table">
+        <tbody>
+          <tr>
+            <td class="prop-key">Player</td>
+            <td>{{floStatus.name}} (FLO ID: {{floStatus.player_id}})</td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="w3font">Game</div>
+      <table v-if="floStatus.game" class="status-table">
+        <tbody>
+            <tr>
+              <td class="prop-key">FLO ID</td>
+              <td>{{floStatus.game.id}}</td>
+            </tr>
+            <tr>
+              <td class="prop-key">Name</td>
+              <td>{{floStatus.game.name}}</td>
+            </tr>
+            <tr>
+              <td class="prop-key">Status</td>
+              <td>{{floStatus.game.status}}</td>
+            </tr>
+            <tr>
+              <td class="prop-key">Map</td>
+              <td>{{floStatus.game.map.path}}</td>
+            </tr>
+            <tr>
+              <td class="prop-key">Server</td>
+              <td>{{floStatus.game.node.name}}</td>
+            </tr>
+            <tr>
+              <td class="prop-key">Slots</td>
+              <td>
+                <table class="slot-table">
+                  <thead>
+                    <tr>
+                      <td class="prop-key">Player</td>
+                      <td class="prop-key">Team</td>
+                      <td class="prop-key">Race</td>
+                      <td class="prop-key">Status</td>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="(slot, index) in usedSlots" :key="index">
+                      <td>{{slot.player.name}}</td>
+                      <td>{{slot.settings.team}}</td>
+                      <td>{{slot.settings.race}}</td>
+                      <td>{{slot.client_status}}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+        </tbody>
+      </table>
+      <p v-else>Waiting for game data...</p>
+    </template>
+    <p v-else>Waiting for data...</p>
+  </div>
+</template>
+
+<script lang="ts">
+import {Component, Vue} from "vue-property-decorator";
+import LoadingSpinner from "@/home/LoadingSpinner.vue";
+import VueMarkdown from "vue-markdown";
+
+@Component({
+  components: {LoadingSpinner, VueMarkdown}
+})
+export default class StatusScreen extends Vue {
+  async mounted() {
+  }
+
+  get floStatus() {
+    return this.$store.direct.state.floStatus
+  }
+
+  get usedSlots() {
+    const slots = (this.floStatus?.game?.slots ?? []).filter(v => v.settings.status === 'Occupied')
+    return slots
+  }
+}
+</script>
+
+<style scoped type="text/css">
+.status-container{
+  position: absolute;
+  background: rgba(0, 0, 0, 0.7);
+  top: 167px;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
+  width: 1128px;
+  height: 580px;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.prop-key {
+  font-weight: bold;
+  width: 120px;
+  text-align: left;
+}
+
+table.slot-table {
+  border-collapse: collapse;
+  border: 1px solid;
+}
+
+table.slot-table tr {
+  border: 1px solid;
+}
+
+.slot-table td {
+   padding: 4px 8px;
+}
+</style>

--- a/src/update-handling/LauncherStrategy.ts
+++ b/src/update-handling/LauncherStrategy.ts
@@ -1,9 +1,8 @@
 import type { IEndpoint } from "@/background-thread/endpoint/endpoint.service";
 import { AppStore } from "@/globalState/vuex-store";
 import logger from "@/logger";
-import { ipcRenderer } from "electron";
 
-const { remote } = window.require("electron");
+const { remote, ipcRenderer } = window.require("electron");
 const fs = window.require("fs");
 const AdmZip = window.require('adm-zip');
 const arrayBufferToBuffer = window.require('arraybuffer-to-buffer');
@@ -123,7 +122,7 @@ export abstract class LauncherStrategy {
         this.store.commit.updateHandling.START_DLS();
         this.store.dispatch.updateHandling.resetPaths();
         await this.updateIfNeeded();
-        await ipcRenderer.invoke('w3c-add-flo-firewall-rule')
+        await ipcRenderer.invoke('flo-add-firewall-rule')
     }
 
     private async getFolderFromUserIfNeverStarted(

--- a/src/update-handling/LauncherStrategy.ts
+++ b/src/update-handling/LauncherStrategy.ts
@@ -1,4 +1,4 @@
-import { IEndpoint } from "@/globalState/EndpointService";
+import type { IEndpoint } from "@/background-thread/endpoint/endpoint.service";
 import { AppStore } from "@/globalState/vuex-store";
 import logger from "@/logger";
 
@@ -208,7 +208,7 @@ export abstract class LauncherStrategy {
     }
     
     get endpoint() {
-        return this.store.getters.endpointService.selected as IEndpoint
+        return this.store.getters.selectedEndpoint as IEndpoint
     }
 
     get isTest() {

--- a/src/update-handling/LauncherStrategy.ts
+++ b/src/update-handling/LauncherStrategy.ts
@@ -1,4 +1,4 @@
-import { CHINA_ALIYUN_OSS_URL, CHINA_WEBUI_SRC, UPDATE_URL_PROD_CHINA } from "@/constants";
+import { IEndpoint } from "@/globalState/EndpointService";
 import { AppStore } from "@/globalState/vuex-store";
 import logger from "@/logger";
 
@@ -45,7 +45,9 @@ export abstract class LauncherStrategy {
 
         const to = `${this.mapsPath}/${fileName}`;
         logger.info(`Download ${fileName} to: ${to}`)
-        const url = `${this.updateUrl}api/maps/download?mapPath=${fileName}`;
+        const url = this.endpoint.overrideUpdateFileDownloadUrl
+            ? `${this.endpoint.overrideUpdateFileDownloadUrl}maps/${fileName}`
+            : `${this.endpoint.updateUrl}api/maps/download?mapPath=${fileName}`;
 
         try {
             const fileBytesArray = await this.downloadFileWithProgress(url, onProgress);
@@ -204,9 +206,9 @@ export abstract class LauncherStrategy {
     private updateDownloadProgress(progress: number) {
         this.store.commit.updateHandling.DOWNLOAD_PROGRESS(progress);
     }
-
-    get updateUrl() {
-        return this.store.state.updateUrl;
+    
+    get endpoint() {
+        return this.store.getters.endpointService.selected as IEndpoint
     }
 
     get isTest() {
@@ -220,7 +222,9 @@ export abstract class LauncherStrategy {
 
     private async downloadAndWriteFile(fileName: string, to: string, onProgress?: (percentage: number) => void) {
         logger.info(`Download ${fileName} to: ${to}`)
-        const url = `${this.updateUrl}api/${fileName}?ptr=${this.isTest}`;
+        const url = this.endpoint.overrideUpdateFileDownloadUrl 
+            ? `${this.endpoint.overrideUpdateFileDownloadUrl}${fileName}`
+            : `${this.endpoint.updateUrl}api/${fileName}?ptr=${this.isTest}`;
 
         try {
             const fileBytesArray = await this.downloadFileWithProgress(url, onProgress);
@@ -246,52 +250,6 @@ export abstract class LauncherStrategy {
         } catch (e) {
             logger.error(e);
         }
-    }
-
-    public async repairChina() {
-        if (!this.w3PathIsValid) return;
-        this.store.commit.updateHandling.START_DLS();
-        try {
-            const { version } = await fetch(`${UPDATE_URL_PROD_CHINA}api/client-version`)
-                .then(res => res.json())
-            logger.info(`Latest client version is ${version}`)
-
-            {
-                const to = this.mapsPath;
-                const url = `${CHINA_ALIYUN_OSS_URL}/update-service-content/maps_v${version}.zip`;
-                const fileBytesArray = await this.downloadFileWithProgress(url, this.updateDownloadProgress.bind(this));
-                const buffer = arrayBufferToBuffer(fileBytesArray);
-                const zip = new AdmZip(buffer);
-                
-                try {
-                    zip.extractAllTo(to, true);
-                    zip.extractAllTo(to.replace("Warcraft III", "Warcraft III Public Test"), true);
-                } catch (e) {
-                    logger.info(`normal download threw exception: ${e}`)
-                    const temPath = `${remote.app.getPath("appData")}/w3champions/china_maps_temp`;
-                    zip.extractAllTo(temPath, true);
-                    logger.info(`try as sudo now from: ${temPath} to: ${to}`)
-                    this.store.dispatch.updateHandling.sudoCopyFromTo({ from: temPath, to });
-                }
-            }
-
-            {
-                const to = `${this.w3Path}/webui/index.html`
-                try {
-                    fs.writeFileSync(to, CHINA_WEBUI_SRC);
-                } catch (e) {
-                    logger.info(`normal write threw exception: ${e}`)
-                    const temPath = `${remote.app.getPath("appData")}/w3champions/china_webui_temp`;
-                    fs.writeFileSync(temPath, CHINA_WEBUI_SRC);
-                    this.store.dispatch.updateHandling.sudoCopyFromTo({ from: temPath, to });
-                }
-            }
-        } catch (e) {
-            logger.error(e);
-            alert(`Error: ${e}`)
-        }
-        this.store.commit.updateHandling.FINISH_WEBUI_DL();
-        this.store.commit.updateHandling.FINISH_MAPS_DL();
     }
 
     public async updateIfNeeded() {

--- a/src/update-handling/UpdateSettingsScreen.vue
+++ b/src/update-handling/UpdateSettingsScreen.vue
@@ -26,20 +26,8 @@
         <ColorPicker text="Enemy Color" :color="enemyColor" :onSwitchColor="switchEnemyColor"/>
         <ColorPicker text="Allies Color" :color="alliesColor" :onSwitchColor="switchAlliesColor"/>
       </div>
-      <div class="options-header w3font" style="margin-top: 20px">Misc</div>
-      <div class="misc-wrapper">
-        <div style="display: flex">
-          <div :class="isChinaProxyEnabled ? 'toggle-on' : 'toggle-off'" @click="toggleChinaProxy"/>
-          <div style="line-height: 31px; margin-left: 5px">China proxy</div>
-        </div>
-      </div>
       <div class="button-bar">
-        <template v-if="isChinaProxyEnabled">
-          <div @click="repairW3cChina" :disabled="isLoading" class="button-bar-button w3font">
-            修复客户端
-          </div>
-        </template>
-        <template v-else>
+        <template>
           <div @click="repairW3c" :disabled="isLoading" class="button-bar-button w3font">
             Reset W3C
           </div>
@@ -53,7 +41,10 @@
       </div>
       <div class="version-wrapper">
         <div>
-          Warcraft 3 Champions Version: {{w3cVersion}}
+          W3Champions Endpoint: {{selectedEndpoint.id}}
+        </div>
+        <div>
+          W3Champions Version: {{w3cVersion}}
         </div>
         <div>
           Launcher Version: {{ currentLauncherVersion }}
@@ -100,6 +91,10 @@ export default class UpdateSettingsScreen extends Vue {
     return this.$store.direct.state.colorPicker.allyColor;
   }
 
+  get selectedEndpoint() {
+    return this.$store.direct.state.selectedEndpoint;
+  }
+
   public switchOwnColor(newColor: string) {
     this.$store.direct.dispatch.colorPicker.switchOwnColor(newColor);
   }
@@ -122,16 +117,8 @@ export default class UpdateSettingsScreen extends Vue {
     return this.$store.direct.state.colorPicker.isTeamColorsEnabled;
   }
 
-  get isChinaProxyEnabled() {
-    return this.$store.direct.state.isChinaProxyEnabled
-  }
-
   public async toggleTeamColors() {
     await this.$store.direct.dispatch.colorPicker.saveIsTeamColorsEnabled(!this.isTeamColorsEnabled);
-  }
-
-  public async toggleChinaProxy() {
-    await this.$store.direct.dispatch.setChinaProxy(!this.isChinaProxyEnabled);
   }
 
   get explanationW3Wrong() {
@@ -221,12 +208,6 @@ export default class UpdateSettingsScreen extends Vue {
     await this.updateStrategy.repairWc3();
   }
 
-    public async repairW3cChina() {
-    if (this.isLoading) return;
-
-    await this.updateStrategy.repairChina();
-  }
-
   private isWindows() {
     return this.$store.state.isWindows;
   }
@@ -240,21 +221,17 @@ export default class UpdateSettingsScreen extends Vue {
   justify-content: space-around;
   align-items: center;
 }
-
 .button-bar{
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-around;
-
-  margin-top: 10px;
+  margin-top: 50px;
   width: 671px;
   height: 71px;
-
   background: url("~@/assets/images/home/Header_Buttons_Frame.png") center no-repeat;
   background-size: cover;
 }
-
 .button-bar-button {
   font-size: 20px;
   width: 208px;
@@ -265,12 +242,10 @@ export default class UpdateSettingsScreen extends Vue {
   background: url("~@/assets/images/home/Button_Blue.png") center no-repeat;
   background-size: cover;
 }
-
 .button-bar-button:active{
   background: url("~@/assets/images/home/Button_Blue_Active.png") center no-repeat;
   background-size: cover;
 }
-
 .reset-button-line {
   display: flex;
   justify-content: space-between;
@@ -282,54 +257,45 @@ export default class UpdateSettingsScreen extends Vue {
   padding-right: 32px;
   user-select: text;
 }
-
-.toggle-on{
+.team-colors-on{
   background: url("~@/assets/images/settings/Settings_Toggle_On.png") center no-repeat;
   background-size: cover;
   width: 31px;
   height: 30px;
 }
-
-.toggle-off {
+.team-colors-off {
   background: url("~@/assets/images/settings/Settings_Toggle_Off.png") center no-repeat;
   background-size: cover;
   width: 31px;
   height: 30px;
 }
-
 .path-is-wrong {
   background: url("~@/assets/images/settings/Settings_Directory_Frame_Error.png") no-repeat center;
   background-size: cover;
 }
-
 .path-is-right {
   background: url("~@/assets/images/settings/Settings_Directory_Frame.png") no-repeat center;
   background-size: cover;
 }
-
 .disabled-option{
   color: rgb(140, 137, 137) !important;
 }
-
 .reset-button {
   width: 36px;
   height: 36px;
   background: url("~@/assets/images/icons/folder-icon-resting.png") no-repeat center;
   background-size: cover;
 }
-
 .reset-button:hover {
   background: url("~@/assets/images/icons/folder-icon-hover.png") no-repeat center;
   background-size: cover;
   cursor: pointer;
 }
-
 .version-wrapper {
   padding-right: 20px;
-  padding-top: 10px;
+  padding-top: 30px;
   text-align: right
 }
-
 .color-pick-bar {
   margin-top: 10px;
   background: url("~@/assets/images/home/Header_Buttons_Frame.png") no-repeat center;
@@ -341,11 +307,9 @@ export default class UpdateSettingsScreen extends Vue {
   justify-content: space-around;
   align-items: center;
 }
-
 .options-header {
   font-size: 18px;
 }
-
 .bnet-icon {
   background: url("~@/assets/images/settings/Settings_Bnet_Icon.png") no-repeat center;
   background-size: cover;
@@ -354,7 +318,6 @@ export default class UpdateSettingsScreen extends Vue {
   height: 24px;
   width: 24px;
 }
-
 .w3c-icon {
   background: url("~@/assets/images/settings/Settings_W3_Icon.png") no-repeat center;
   background-size: cover;
@@ -363,24 +326,11 @@ export default class UpdateSettingsScreen extends Vue {
   height: 26px;
   width: 30px;
 }
-
 .location-wrapper {
   background: url("~@/assets/images/settings/Settings_Directory_Text_Frame.png") no-repeat center;
   background-size: cover;
   padding: 28px 30px 30px;
   height: 154px;
   width: 605px;
-}
-
-.misc-wrapper {
-  margin-top: 10px;
-  background: url("~@/assets/images/home/Header_Buttons_Frame.png") no-repeat center;
-  height: 71px;
-  width: 671px;
-  background-size: cover;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
-  align-items: center;
 }
 </style>

--- a/src/update-handling/UpdateSettingsScreen.vue
+++ b/src/update-handling/UpdateSettingsScreen.vue
@@ -18,7 +18,7 @@
       <div class="options-header w3font" style="margin-top: 20px">Color Settings</div>
       <div class="color-pick-bar">
         <div style="display: flex">
-          <div :class="isTeamColorsEnabled ? 'team-colors-on' : 'team-colors-off'" @click="toggleTeamColors"/>
+          <div :class="isTeamColorsEnabled ? 'toggle-on' : 'toggle-off'" @click="toggleTeamColors"/>
           <div style="line-height: 31px; margin-left: 5px">Team colors</div>
         </div>
 
@@ -26,16 +26,30 @@
         <ColorPicker text="Enemy Color" :color="enemyColor" :onSwitchColor="switchEnemyColor"/>
         <ColorPicker text="Allies Color" :color="alliesColor" :onSwitchColor="switchAlliesColor"/>
       </div>
+      <div class="options-header w3font" style="margin-top: 20px">Misc</div>
+      <div class="misc-wrapper">
+        <div style="display: flex">
+          <div :class="isChinaProxyEnabled ? 'toggle-on' : 'toggle-off'" @click="toggleChinaProxy"/>
+          <div style="line-height: 31px; margin-left: 5px">China proxy</div>
+        </div>
+      </div>
       <div class="button-bar">
-        <div @click="repairW3c" :disabled="isLoading" class="button-bar-button w3font">
-          Reset W3C
-        </div>
-        <div @click="redownloadW3c" :disabled="isLoading" class="button-bar-button w3font" :class="isW3LocationWrong ? 'disabled-option' : ''" :title="explanationW3Wrong">
-          Redownload
-        </div>
-        <div @click="toggleVersion" class="button-bar-button w3font" :class="isW3LocationWrong ? 'disabled-option' : ''" :title="explanationW3Wrong">
-          Switch to {{ !isTest ? "PTR" : "LIVE" }}
-        </div>
+        <template v-if="isChinaProxyEnabled">
+          <div @click="repairW3cChina" :disabled="isLoading" class="button-bar-button w3font">
+            修复客户端
+          </div>
+        </template>
+        <template v-else>
+          <div @click="repairW3c" :disabled="isLoading" class="button-bar-button w3font">
+            Reset W3C
+          </div>
+          <div @click="redownloadW3c" :disabled="isLoading" class="button-bar-button w3font" :class="isW3LocationWrong ? 'disabled-option' : ''" :title="explanationW3Wrong">
+            Redownload
+          </div>
+          <div @click="toggleVersion" class="button-bar-button w3font" :class="isW3LocationWrong ? 'disabled-option' : ''" :title="explanationW3Wrong">
+            Switch to {{ !isTest ? "PTR" : "LIVE" }}
+          </div>
+        </template>
       </div>
       <div class="version-wrapper">
         <div>
@@ -108,8 +122,16 @@ export default class UpdateSettingsScreen extends Vue {
     return this.$store.direct.state.colorPicker.isTeamColorsEnabled;
   }
 
+  get isChinaProxyEnabled() {
+    return this.$store.direct.state.isChinaProxyEnabled
+  }
+
   public async toggleTeamColors() {
     await this.$store.direct.dispatch.colorPicker.saveIsTeamColorsEnabled(!this.isTeamColorsEnabled);
+  }
+
+  public async toggleChinaProxy() {
+    await this.$store.direct.dispatch.setChinaProxy(!this.isChinaProxyEnabled);
   }
 
   get explanationW3Wrong() {
@@ -199,6 +221,12 @@ export default class UpdateSettingsScreen extends Vue {
     await this.updateStrategy.repairWc3();
   }
 
+    public async repairW3cChina() {
+    if (this.isLoading) return;
+
+    await this.updateStrategy.repairChina();
+  }
+
   private isWindows() {
     return this.$store.state.isWindows;
   }
@@ -219,7 +247,7 @@ export default class UpdateSettingsScreen extends Vue {
   align-items: center;
   justify-content: space-around;
 
-  margin-top: 50px;
+  margin-top: 10px;
   width: 671px;
   height: 71px;
 
@@ -255,14 +283,14 @@ export default class UpdateSettingsScreen extends Vue {
   user-select: text;
 }
 
-.team-colors-on{
+.toggle-on{
   background: url("~@/assets/images/settings/Settings_Toggle_On.png") center no-repeat;
   background-size: cover;
   width: 31px;
   height: 30px;
 }
 
-.team-colors-off {
+.toggle-off {
   background: url("~@/assets/images/settings/Settings_Toggle_Off.png") center no-repeat;
   background-size: cover;
   width: 31px;
@@ -298,7 +326,7 @@ export default class UpdateSettingsScreen extends Vue {
 
 .version-wrapper {
   padding-right: 20px;
-  padding-top: 30px;
+  padding-top: 10px;
   text-align: right
 }
 
@@ -342,5 +370,17 @@ export default class UpdateSettingsScreen extends Vue {
   padding: 28px 30px 30px;
   height: 154px;
   width: 605px;
+}
+
+.misc-wrapper {
+  margin-top: 10px;
+  background: url("~@/assets/images/home/Header_Buttons_Frame.png") no-repeat center;
+  height: 71px;
+  width: 671px;
+  background-size: cover;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: center;
 }
 </style>

--- a/src/update-handling/UpdateSettingsScreen.vue
+++ b/src/update-handling/UpdateSettingsScreen.vue
@@ -207,10 +207,6 @@ export default class UpdateSettingsScreen extends Vue {
 
     await this.updateStrategy.repairWc3();
   }
-
-  private isWindows() {
-    return this.$store.state.isWindows;
-  }
 }
 </script>
 

--- a/src/update-handling/UpdateSettingsScreen.vue
+++ b/src/update-handling/UpdateSettingsScreen.vue
@@ -293,7 +293,7 @@ export default class UpdateSettingsScreen extends Vue {
 }
 .version-wrapper {
   padding-right: 20px;
-  padding-top: 30px;
+  padding-top: 10px;
   text-align: right
 }
 .color-pick-bar {

--- a/src/update-handling/updateStore.ts
+++ b/src/update-handling/updateStore.ts
@@ -35,7 +35,6 @@ const mod = {
       const { commit, rootGetters } = moduleActionContext(context, mod);
 
       rootGetters.updateService.saveLocalW3CVersion(version);
-
       commit.SET_LOCAL_W3C_VERSION(version);
     },
     saveW3Path(context: ActionContext<UpdateHandlingState, RootState>, version: string) {
@@ -65,10 +64,10 @@ const mod = {
       commit.SET_CURRENT_LAUNCHER_VERSION(remote.app.getVersion());
     },
     async loadOnlineW3CVersion(context: ActionContext<UpdateHandlingState, RootState>) {
-      const { commit, rootState } = moduleActionContext(context, mod);
+      const { commit, rootGetters } = moduleActionContext(context, mod);
 
-      try {
-        const result = await fetch(`${rootState.updateUrl}api/client-version`);
+      try { 
+        const result = await fetch(`${rootGetters.endpointService.selected.updateUrl}api/client-version`);
         const version = await result.json();
         commit.SET_ONLINE_W3C_VERSION(version.version);
       } catch (e) {

--- a/src/update-handling/updateStore.ts
+++ b/src/update-handling/updateStore.ts
@@ -67,7 +67,7 @@ const mod = {
       const { commit, rootGetters } = moduleActionContext(context, mod);
 
       try { 
-        const result = await fetch(`${rootGetters.endpointService.selected.updateUrl}api/client-version`);
+        const result = await fetch(`${rootGetters.selectedEndpoint?.updateUrl}api/client-version`);
         const version = await result.json();
         commit.SET_ONLINE_W3C_VERSION(version.version);
       } catch (e) {


### PR DESCRIPTION
- Added proxied endpoint URLs for China
- Added `EndpointService` to pick the fastest endpoint on start
- Added a `Status` tab to display information sent by flo-worker
- Changed startup flow: start `Selecting server...` overlay -> Detect the fastest endpoint -> call autoUpdate -> init news & config..
- Try to add flo-worker firewall rule with `RESET W3C` button