### PR TITLE
silence warning for hotkey registration failure

### DIFF
--- a/src/hot-keys/ItemHotkeyRegistrationService.ts
+++ b/src/hot-keys/ItemHotkeyRegistrationService.ts
@@ -199,7 +199,6 @@ export class ItemHotkeyRegistrationService {
             globalShortcut.register(keyCode, fkt)
         } catch (e) {
             logger.error(`Failed to register combo: ${combiAsString(combo)}`);
-            alert(`Could not register combo: ${combiAsString(combo)}. Switching to an english keyboard layout should help. Nevertheless, please reach out on discord to get this fixed for good =)`)
         }
     }
 


### PR DESCRIPTION
I'm getting an alert popup often when games start, which disables my enter key, esc key, etc, and minimizes my game...
until I close the alert box on the launcher. 
Imo we never need an alert popup that is going to take keyboard control and possibly impact someone's match. All this fix does is remove the alert, the console will still catch this error.