### PR TITLE
Turn on local files on launch

### DIFF
--- a/src/update-handling/LauncherStrategy.ts
+++ b/src/update-handling/LauncherStrategy.ts
@@ -34,6 +34,7 @@ export abstract class LauncherStrategy {
 
     public startWc3() {
         this.makeSureJoinBugFilesAreGone();
+        this.turnOnLocalFiles();
         this.startWc3Process(this.bnetPath);
     }
 


### PR DESCRIPTION
Some people don't get their local files set up correctly sometimes, and there is no reason not to make sure they're on every time the start button is pressed.