### PR TITLE
W3c 154/display wc3 dir correctly in settings

### DIFF
--- a/src/update-handling/LauncherStrategy.ts
+++ b/src/update-handling/LauncherStrategy.ts
@@ -185,11 +185,15 @@ export abstract class LauncherStrategy {
     }
 
     private async downloadWebui() {
-        await this.downloadAndWriteFile("webui", this.w3Path);
+        if (fs.existsSync(`${this.w3Path}/_retail_`)) {
+            await this.downloadAndWriteFile("webui", `${this.w3Path}/_retail_`);
+        } else {
+            await this.downloadAndWriteFile("webui", this.w3Path);
+        }
     }
 
     private async downloadWebuiToPTR() {
-        await this.downloadAndWriteFile("webui", this.w3Path.replace('retail', 'ptr'));
+        await this.downloadAndWriteFile("webui", `${this.w3Path}/_ptr_`);
     }
 
     private updateDownloadProgress(progress: number) {
@@ -338,16 +342,12 @@ export abstract class LauncherStrategy {
         }
 
         logger.info("default wc3 path: " + defaultW3Path);
-        let w3path = await this.getFolderFromUserIfNeverStarted(
+        const w3path = await this.getFolderFromUserIfNeverStarted(
             this.w3Path,
             defaultW3Path,
             "Warcraft III not found",
             "Warcraft III folder not found, please locate it manually"
         );
-
-        if (fs.existsSync(`${w3path}/_retail_`)) {
-            w3path = `${w3path}/_retail_`;
-        }
 
         if (w3path === "defaultPath") {
             return "";

--- a/src/update-handling/LauncherStrategy.ts
+++ b/src/update-handling/LauncherStrategy.ts
@@ -308,19 +308,14 @@ export abstract class LauncherStrategy {
 
     public async hardSetW3cPath() {
         const path = await this.openSelectFolderDialog(this.w3PathWithOutRetail);
-        if (!path || path === this.w3PathWithOutRetail) return;
+        if (!path) return;
         this.store.commit.updateHandling.SET_W3_PATH(path);
         logger.info(`w3 path to check: ${path}`)
         if (!fs.existsSync(`${path}/${this.getDefaultWc3Executable()}`)) {
             this.store.commit.updateHandling.W3_PATH_IS_INVALID(true);
         } else {
             this.store.commit.updateHandling.W3_PATH_IS_INVALID(false);
-
-            if (fs.existsSync(`${this.w3Path}/_retail_`)) {
-                this.store.dispatch.updateHandling.saveW3Path(`${path}/_retail_`)
-            } else {
-                this.store.dispatch.updateHandling.saveW3Path(path)
-            }
+            this.store.dispatch.updateHandling.saveW3Path(path);
         }
 
         if (this.w3PathIsValid) {

--- a/src/update-handling/UpdateSettingsScreen.vue
+++ b/src/update-handling/UpdateSettingsScreen.vue
@@ -173,7 +173,7 @@ export default class UpdateSettingsScreen extends Vue {
   }
 
   get w3Path(): string {
-    return this.updateStrategy.w3PathWithOutRetail;
+    return this.updateStrategy.w3Path;
   }
 
   get news() {

--- a/src/update-handling/UpdateSettingsScreen.vue
+++ b/src/update-handling/UpdateSettingsScreen.vue
@@ -3,23 +3,23 @@
     <LoadingSpinner :style="`visibility: ${isLoading ? 'visible' : 'hidden'}`" />
     <div style="padding-top: 40px">
       <div class="options-header w3font" style="margin-bottom: 10px">Directory Settings</div>
-        <div class="location-wrapper">
-        <div class="w3c-icon" :title="`Enter the location to wc3 (Usually ${defaultW3Location})`"/>
-        <div class="reset-button-line"  :class="isW3LocationWrong ? 'path-is-wrong' : 'path-is-right'">
-          <div :title="explanationW3Wrong">{{w3Path}}</div>
-          <div class="reset-button" @click="resetW3Path" />
+      <div class="location-wrapper">
+        <div class="w3c-icon" :title="`Enter the location to wc3 (Usually ${defaultW3Location})`"></div>
+        <div class="reset-button-line"  :class="isW3LocationWrong ? 'path-is-wrong' : 'path-is-right'" :title="explanationW3Wrong">
+          <div>{{w3Path}}</div>
+          <div class="reset-button" @click="resetW3Path"></div>
         </div>
-        <div class="bnet-icon" :title="`Enter the location to wc3 (Usually ${defaultBnetLocation})`" />
-        <div class="reset-button-line" :class="isBnetLocationWrong ? 'path-is-wrong' : 'path-is-right'">
-          <div :title="explanationBnetWrong">{{battleNet}}</div>
-          <div class="reset-button" @click="resetBnetPath" />
+        <div class="bnet-icon" :title="`Enter the location to wc3 (Usually ${defaultBnetLocation})`"></div>
+        <div class="reset-button-line" :class="isBnetLocationWrong ? 'path-is-wrong' : 'path-is-right'" :title="explanationBnetWrong">
+          <div>{{battleNet}}</div>
+          <div class="reset-button" @click="resetBnetPath"></div>
         </div>
       </div>
       <div class="options-header w3font" style="margin-top: 20px">Color Settings</div>
       <div class="color-pick-bar">
         <div style="display: flex">
-          <div :class="isTeamColorsEnabled ? 'team-colors-on' : 'team-colors-off'" @click="toggleTeamColors"/>
-          <div style="line-height: 31px; margin-left: 5px">Team colors</div>
+          <div :class="isTeamColorsEnabled ? 'team-colors-on' : 'team-colors-off'" @click="toggleTeamColors"></div>
+          <div style="line-height: 31px; margin-left: 5px">Team Colors</div>
         </div>
 
         <ColorPicker text="Own Color" :color="ownColor" :onSwitchColor="switchOwnColor"/>
@@ -114,7 +114,7 @@ export default class UpdateSettingsScreen extends Vue {
 
   get explanationW3Wrong() {
     if (this.isW3LocationWrong) {
-      return "Warcraft III location wrong, please select a different Folder"
+      return "Warcraft III location is wrong, please select a different folder"
     }
 
     return ""
@@ -122,7 +122,7 @@ export default class UpdateSettingsScreen extends Vue {
 
   get explanationBnetWrong() {
     if (this.isBnetLocationWrong) {
-      return "BattleNet location wrong, please select a different Folder"
+      return "BattleNet location is wrong, please select a different folder"
     }
 
     return ""


### PR DESCRIPTION
Fixes a problem in the Settings-tab where if you choose the _retail_ folder when manually choosing a wc3 path, it is not displayed correctly in the input field. After that, you can't choose the Warcraft III folder again. You need to select a different folder first, then Warcraft III.