### PR TITLE
Handle more cases to prevent join bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w3champions",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "description": "Always stay up to date with this Launcher for the community Ladder Warcraft 3 Champions.",
   "author": "Deespul LLC",

--- a/src/update-handling/LauncherStrategy.ts
+++ b/src/update-handling/LauncherStrategy.ts
@@ -400,6 +400,11 @@ export abstract class LauncherStrategy {
     private makeSureJoinBugFilesAreGone() {
         try {
 
+            if (fs.existsSync(`${this.w3Path}/Units/UnitData.slk`)) {
+                logger.info(`deleted modified slk: ${this.w3Path}/Units/UnitData.slk`)
+                fs.unlinkSync(`${this.w3Path}/Units/UnitData.slk`, (e: Error) => { logger.error(e) })
+            }
+
             if (fs.existsSync(`${this.w3Path}/Maps/W3Champions`)) {
                 logger.info(`delete maps in ${this.w3Path}/Maps/W3Champions`)
                 fs.rmdirSync(`${this.w3Path}/Maps/W3Champions`, { recursive: true }, (e: Error) => { logger.error(e) })


### PR DESCRIPTION
Removes and reports unitdata.slk if found in the local files.
This SLK stores all unit and building data, so modifying it has unintended consequences.
Removing it is required to allow for a stable melee experience. 
Relies on w3champions/ingame-client#214 to correctly report problems