### PR TITLE
Fix PTR

### DIFF
--- a/src/background-thread/endpoint/endpoint.service.ts
+++ b/src/background-thread/endpoint/endpoint.service.ts
@@ -1,3 +1,4 @@
+import { IDENTIFICATION_PUBLIC_KEY_PROD, IDENTIFICATION_PUBLIC_KEY_TEST } from "@/constants";
 import { BrowserWindow, ipcMain } from "electron";
 import fetch from 'electron-fetch'
 
@@ -6,6 +7,7 @@ export interface IEndpoint {
   updateUrl: string;
   newsUrl: string;
   identificationUrl: string;
+  identificationPublicKey: string;
   floControllerHost: string;
   staticBaseUpdateFileUrl?: string;
 }
@@ -16,6 +18,7 @@ const ENDPOINTS_PROD: IEndpoint[] = [
     updateUrl: "https://update-service.w3champions.com/",
     newsUrl: "https://statistic-service.w3champions.com/",
     identificationUrl: "https://identification-service.w3champions.com/",
+    identificationPublicKey: IDENTIFICATION_PUBLIC_KEY_PROD,
     floControllerHost: "service.w3flo.com",
   },
   {
@@ -23,6 +26,7 @@ const ENDPOINTS_PROD: IEndpoint[] = [
     updateUrl: "http://45.194.17.149:8084/",
     newsUrl: "http://45.194.17.149:8083/",
     identificationUrl: "http://45.194.17.149:8082/",
+    identificationPublicKey: IDENTIFICATION_PUBLIC_KEY_PROD, //unused?
     floControllerHost: "bd5271.pathx.ucloudgda.com",
     staticBaseUpdateFileUrl: 'https://w3champions.oss-cn-shanghai.aliyuncs.com/update-service-content/'
   },
@@ -34,6 +38,7 @@ const TEST_ENDPOINTS: IEndpoint[] = [
     updateUrl: "https://update-service.test.w3champions.com/",
     newsUrl: "https://statistic-service.test.w3champions.com/",
     identificationUrl: "https://identification-service.test.w3champions.com/",
+    identificationPublicKey: IDENTIFICATION_PUBLIC_KEY_TEST,
     floControllerHost: "157.90.1.251",
   }
 ]

--- a/src/flo-integration/flo-worker.service.ts
+++ b/src/flo-integration/flo-worker.service.ts
@@ -28,13 +28,11 @@ export class FloWorkerService {
         }
         this.inited = true;
 
-        store.original.subscribeAction((x, y) => {
-            if (x.type == 'setTestMode') {
-                this.reloadWorkers(x.payload as boolean);
-            }
+        ipcRenderer.on('w3c-endpoint-selected', () => {
+                this.reloadWorkers();
         });
 
-        this.reloadWorkers(store.state.isTest);
+        this.reloadWorkers();
 
         ingameBridge.on(ELauncherMessageType.FLO_AUTH, (event: IIngameBridgeEvent) => {
             const data = event.data as IFloAuthData;
@@ -116,7 +114,7 @@ export class FloWorkerService {
         }
     }
 
-    private reloadWorkers(isTest: boolean) {
+    private reloadWorkers() {
         for (const worker of this.workers) {
             worker?.stopWorker();
         }

--- a/src/globalState/AuthenticationService.ts
+++ b/src/globalState/AuthenticationService.ts
@@ -45,7 +45,7 @@ export class AuthenticationService {
 
     public getUserInfo(token: string): W3cToken | null {
         try {
-            const verifiedToken = jwt.verify(token, store.state.identificationPublicKey) as W3cToken;
+            const verifiedToken = jwt.verify(token, store.state.selectedEndpoint!.identificationPublicKey) as W3cToken;
             logger.info(`verified token, user is: ${verifiedToken.battleTag}`);
             verifiedToken.jwt = token;
             return verifiedToken;

--- a/src/globalState/rootTypings.ts
+++ b/src/globalState/rootTypings.ts
@@ -6,7 +6,6 @@ export interface RootState {
     selectedEndpoint: IEndpoint | null,
     isWindows: boolean,
     selectedLoginGateway: LoginGW,
-    identificationPublicKey: string,
     news: News[],
     newsLoading: boolean,
     w3cToken: W3cToken | null,

--- a/src/globalState/vuex-store.ts
+++ b/src/globalState/vuex-store.ts
@@ -10,7 +10,6 @@ import {UpdateService} from "@/update-handling/UpdateService";
 import {UpdateHandlingState} from "@/update-handling/updateTypes";
 import {VersionService} from "@/globalState/VersionService";
 import {
-  IDENTIFICATION_PUBLIC_KEY_PROD,
   OAUTH_ENABLED,
 } from "@/constants";
 import {ItemHotkeyRegistrationService} from "@/hot-keys/ItemHotkeyRegistrationService";
@@ -40,7 +39,6 @@ const mod = {
   state: {
     isTest: false,
     selectedEndpoint: null,
-    identificationPublicKey: IDENTIFICATION_PUBLIC_KEY_PROD,
     news: [] as News[],
     newsLoading: false,
     w3cToken: null,


### PR DESCRIPTION
The PTR identification key was disconnected during a recent endpoint refactoring. To respect endpoints containing identification service URLs now, the public keys should also be a part of endpoints.
Additionally, Flo workers were being recreated before the endpoint was changed when switching modes, so now the worker recreation will wait for the endpoint selection