### PR TITLE
Resizable Launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w3champions",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Always stay up to date with this Launcher for the community Ladder Warcraft 3 Champions.",
   "author": "Deespul LLC",

--- a/src/App.vue
+++ b/src/App.vue
@@ -169,17 +169,22 @@ export default class App extends Vue {
 body {
   margin: 0;
   font-family: "Inter";
+  background-color: rgba(0, 0, 0, 0.007);
   color: antiquewhite;
   user-select: none;
-  overflow:hidden;
+  overflow: hidden;
 }
+
 ::-webkit-scrollbar {
-width: 16px;
-height: 16px; }
+  width: 16px;
+  height: 16px;
+}
 
 ::-webkit-scrollbar-thumb {
-background-color: rgba(0, 0, 0, 0.2);
--webkit-box-shadow: inset 1px 1px 0 rgba(0,0.07,0,0.10),inset 0 -1px 0 rgba(0,0.07,0,0.07); }
+  background-color: rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow: inset 1px 1px 0 rgba(0,0.07,0,0.10), inset 0 -1px 0 rgba(0,0.07,0,0.07);
+}
+
 a {
   color: inherit;
 }
@@ -188,14 +193,13 @@ a {
   font-family: "Friz Quadrata Regular OS";
   color: #ffd528;
   text-transform: uppercase;
-  text-shadow:  3px 3px 1px #000000;
+  text-shadow: 3px 3px 1px #000000;
 }
 
 .app-container {
   background: url("~@/assets/images/home/Maon_Border.png") center no-repeat;
+  background-size: 100vw 100vh;
   height: 100vh;
-  background-size: cover;
-
 }
 
 .fullscreen-bg__video {
@@ -214,10 +218,9 @@ a {
   position: absolute;
   background: url("~@/assets/images/home/Static_Background.png") center no-repeat;
   background-size: cover;
-  z-index: -100;
-  top: 10px;
-  width: 100%;
-  height: 100%;
+  z-index: -101;
+  width: 95vw;
+  height: 95vh;
 }
 
 .content-modal-wrapper {
@@ -229,9 +232,9 @@ a {
 }
 
 .content-modal {
-  margin-top: 8vh;
-  height: 80%;
-  width: 100%;
+  margin-top: 20px;
+  height: 67vh;
+  width: 90vw;
 }
 
 .close-button {
@@ -240,8 +243,8 @@ a {
   z-index: 1;
   background: url("~@/assets/images/home/Exit_Button.png") center no-repeat;
   background-size: cover;
-  height: 60px;
-  width: 61px;
+  height: max(60px, 6vh);
+  width: max(60px, 6vh);
   cursor: pointer;
   top: 0%;
   right: 0%;
@@ -279,11 +282,13 @@ a {
 }
 
 .gw-selection-wrapper {
-  position: absolute;
+  position: relative;
   z-index: 400;
   display: flex;
   width: 50%;
-  top: 550px;
+  top: 55vh;
+  left: -2vw;
+  align-items: center;
   justify-content: space-around;
   padding-left: 25%;
   padding-right: 25%;

--- a/src/background.ts
+++ b/src/background.ts
@@ -70,7 +70,7 @@ function createWindow() {
     // height: 664,
     width: 1275,
     height: 830,
-    resizable: false,
+    resizable: true,
     frame: false,
     titleBarStyle: 'hidden',
     transparent: true,

--- a/src/home/ButtonWarcraft.vue
+++ b/src/home/ButtonWarcraft.vue
@@ -19,17 +19,17 @@ export default class ButtonWarcraft extends Vue {
   -webkit-app-region: no-drag;
   font-size: 1.3em;
   text-align: center;
-  line-height: 56px;
-  width: 210px;
-  height: 55px;
+  line-height: 50px;
+  width: 20vw;
+  height: 50px;
   background: url("~@/assets/images/home/Button_Blue.png") center no-repeat;
-  background-size: cover;
+  background-size: 100% 100%;
   cursor: pointer;
 }
 
 .header-item:active {
   background: url("~@/assets/images/home/Button_Blue_Active.png") center no-repeat;
-  background-size: cover;
+  background-size: 100% 100%;
   cursor: pointer;
 }
 

--- a/src/home/HeadLine.vue
+++ b/src/home/HeadLine.vue
@@ -26,9 +26,10 @@ export default class HeadLine extends Vue {
 <style scoped type="text/css">
 .headline-container {
   position: absolute;
-  top: 60px;
+  vertical-align: middle;
   margin-left: auto;
   margin-right: auto;
+  margin-top: 5vh;
   left: 0;
   right: 0;
   display: flex;
@@ -36,12 +37,13 @@ export default class HeadLine extends Vue {
   justify-content: space-evenly;
   align-items: center;
 
-  width: 871px;
-  height: 71px;
+  width: 100vw;
+  height: 13vh;
 }
 
 .headline-wrapper {
   position: inline;
+  margin-left:1%;
   width: 100%;
   height: 15%;
   -webkit-user-select: none;

--- a/src/home/HomeScreen.vue
+++ b/src/home/HomeScreen.vue
@@ -86,7 +86,7 @@ export default class HomeScreen extends Vue {
   }
 
   get isBnetOff() {
-    const runningProcesses = execSync("tasklist /FI \"STATUS eq RUNNING").toString();
+    const runningProcesses = execSync("tasklist /FI \"STATUS eq RUNNING\"").toString();
     const indexOf = runningProcesses.indexOf("Battle.net.exe");
     return indexOf === -1;
   }
@@ -94,39 +94,36 @@ export default class HomeScreen extends Vue {
 </script>
 
 <style scoped type="text/css">
-.home-container{
+.home-container {
   display: flex;
-  height:100%;
+  height: 100%;
   flex-direction: column;
   justify-content: space-around;
   align-items: center;
 }
 
-
 .start-button:disabled {
   opacity: 0.6;
-  cursor:unset;
+  cursor: unset;
 }
 
 .start-button {
   background: url("~@/assets/images/home/Green_Hero_Button_Static.png") no-repeat center;
-  background-size: cover;
+  background-size: 100% 100%;
   border: none;
   outline: inherit;
   cursor: pointer;
-  width: 30%;
+  width: max(30%, 200px);
+  height: max( 10%, 55px);
   text-align: center;
-  line-height: 100%;
+  line-height: max( 8%, 55px);
   font-size: 28px;
-  padding:2%;
-  position:fixed;
-  bottom:5.5%;
+  position: fixed;
+  bottom: 5%;
 }
 
 .start-button:active {
   background: url("~@/assets/images/home/Green_Hero_Button_Active.png") no-repeat center;
-  background-size: cover;
+  background-size: 100% 100%;
 }
-
-
 </style>

--- a/src/home/NewsBanner.vue
+++ b/src/home/NewsBanner.vue
@@ -1,17 +1,17 @@
 <template>
-  <div>
-    <div class="news-buttons-box"         @wheel="onSelectorScroll">
+  <div class="news-container">
+    <div class="news-buttons-box" @wheel="onSelectorScroll">
       <div 
-
-      v-for="(newsItem, index) in news" class="news-selector" :key="newsItem.date" @click="() => selectNews(index)" :class="isSelected(index) ? 'news-selector-selected' : ''"/>
+       v-for="(newsItem, index) in news" class="news-selector" :key="newsItem.date" @click="() => selectNews(index)" :class="isSelected(index) ? 'news-selector-selected' : ''"/>
+    </div>
+    <div class="news-bg">
+      <div class="w3font news-header">{{ selectedNewsDate }}</div>
+      <div class="news-banner">
+          <div class="news-message-box">
+            <div class="news-content" v-if="isNewsHtml" v-html="selectedNewsMessage"></div>
+            <vue-markdown v-else :source="selectedNewsMessage" />
+          </div>
       </div>
-    <div class="w3font news-header">{{ selectedNewsDate }}</div>
-    <div class="news-banner">
-        <div class="news-message-box">
-          <br />
-          <div class="news-content" v-if="isNewsHtml" v-html="selectedNewsMessage"></div>
-          <vue-markdown v-else :source="selectedNewsMessage" />
-        </div>
     </div>
   </div>
 </template>
@@ -68,20 +68,36 @@ export default class NewsBanner extends Vue {
 
 <style scoped type="text/css">
 
-.news-banner{
+.news-container {
+  position: relative;
+  font-size: 2vh;
+  width: 75vw;
+  height: 100%;
+  align-content: center;
+}
+
+.news-bg {
   background: url("~@/assets/images/home/W3Champion_Text_Frame.png") no-repeat center;
-  background-size: cover;
-  font-size: 14px;
-  width: 865px;
-  height: 440px;
+  background-size: 100% 100%;
   display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: calc(100% - 50px);
+}
+
+.news-banner {
+  display: flex;
+  margin-top: 0.7vh;
+  width: 93.4%;
+  height: 87.4%;
   justify-content: center;
 }
     
 .news-header {
-  font-size: 21px;
-  padding-bottom: 10px;
-  text-align:center;
+  font-size: 3vh;
+  margin-top: 2vh;
+  text-align: center;
+  width: 70%;
 }
 
 .news-selector-selected {
@@ -93,34 +109,34 @@ export default class NewsBanner extends Vue {
   margin-right: 8px;
   cursor: pointer;
   margin-left: 8px;
-  height: 24px;
-  width: 24px;
+  height: 25px;
+  width: 25px;
+  margin-top: 4px;
   /* background-color: #697; */
   border-color: rgba(78, 106, 176, 0.508);
   border-style: solid;
   border-radius: 50%;
   position:relative;
-  bottom:18px;
 }
 .news-selector:hover {
   border-color: rgba(69, 98, 173, 0.508);
 }
-.news-buttons-box{
+.news-buttons-box {
+  height: 40px;
   display: flex;
   justify-content: center;
+  margin-top: 1vh;
+  margin-bottom: 0.5vh;
 }
 
-.news-message-box{
-  position:relative;
-  top:30px;
-  left:10px;
-  width: 820px;
-  height: 380px;
-  overflow-y: scroll;
-  scroll-behavior: smooth;
+.news-message-box {
+  position: relative;
+  width: 100%;
 }
 
 .news-content {
-  font-size: 18px;
+  height: 100%;
+  overflow-y: scroll;
+  scroll-behavior: smooth;
 }
 </style>

--- a/src/hot-keys/HotKeySetupScreen.vue
+++ b/src/hot-keys/HotKeySetupScreen.vue
@@ -4,8 +4,8 @@
       <div v-for="race in racesValues" :key="race" class="hotkey-tab" :class="`hotkey-tab-${races[race]}`" @click="() => navigateTo(race)"/>
     </div>
     <div class="tab-container">
-      <div v-if="this.tab === races.items">
-        <ItemHotkeyTab />
+      <div v-if="tab === races.items" style="height:100%">
+        <ItemHotkeyTab style="height:90%"/>
         <div class="wc3hotkey-mode-container">
             <div class="tooltip"> {{hotkeyTooltip}} </div>
             <div :class="hotkeyMode == 0 ? 'rect-button rb-on' : 'rect-button rb-off'" @click="setHotkeyMode(0)"> Classic </div>
@@ -85,7 +85,7 @@ export default class HotKeySetupScreen extends Vue {
 .hotkey-tab {
   cursor: pointer;
   width: 80px;
-  height: 77px;
+  height: 80px;
 }
 
 .hotkey-tab-items {
@@ -120,24 +120,24 @@ export default class HotKeySetupScreen extends Vue {
 
 .hotkey-race-wrapper {
   display: flex;
-  height: 90%;
-  padding: 0% 16% 0% 8%;
+  height: 110%;
+  padding: 0% 5% 0% 5%;
 }
 
 .hotkey-tabs {
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
+  justify-content: space-evenly;
 }
 
 .wc3hotkey-mode-container{
   position:absolute;
-  width: 278px;
+  top: 55.6vh;
+  right: 9.2vw;
+  width: 280px;
   height: 34px;
   background: url("~@/assets/images/settings/SmallFrame.png") center no-repeat;
   background-size: cover;
-  top: 41%;
-  left: 35%;
   display:flex;
 }
 .rect-button{

--- a/src/hot-keys/ItemHotkeys/ItemHotkeyTab.vue
+++ b/src/hot-keys/ItemHotkeys/ItemHotkeyTab.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="hotkey-wrapper">
       <div>
-        <div class="w3font" style="margin-bottom: 15px">Inventory</div>
+        <div class="w3font" style="margin-bottom: 2vh">Inventory</div>
         <table class="item-grid">
           <tr>
             <td class="single-item" @click="() => openChangeHotkeyModal(itemTopLeft)">
@@ -27,8 +27,8 @@
         </table>
       </div>
 
-      <div style="margin-left: 40px">
-        <div class="w3font" style="margin-bottom: 15px; margin-left: 8px">Miscellaneous</div>
+      <div>
+        <div class="w3font" style="margin-bottom: 2vh; margin-left: 1vh">Miscellaneous</div>
         <table class="function-key-grid">
           <tr>
             <td class="single-item function-item" @click="() => openChangeHotkeyModal(f1Key)">{{getKeyComboOf(f1Key)}} <div class="foot-note">F1</div></td>
@@ -40,16 +40,16 @@
       </div>
     </div>
 
-    <div style="position:absolute; right: 133px; top: 210px" :class="modal ? 'visible' : 'hidden'" class="current-selection-container">
+    <div style="position:absolute; right: 12vw; top: 25vh" :class="modal ? 'visible' : 'hidden'" class="current-selection-container">
       <div style="display: flex; flex-direction: row">
         <div style="height: 64px; width: 64px; margin: 10px;" class="function-item w3font">
-          <div style="padding-top: 38px; position: absolute; right: 7px">
+          <div style="line-height:64px; width:64px; text-align:center; position: absolute">
             {{ hotKeyCombo }}
           </div>
         </div>
-        <div style="margin-top: 15px">
+        <div style="align-self:center">
           <div class="w3font">Press desired key</div>
-          <div style="cursor: pointer; color: aliceblue; margin-top: 18px; font-size: 14px" class="w3font" @click="removeHotKey">Remove</div>
+          <div style="cursor: pointer; color: aliceblue; margin-top: 2vh; font-size: 14px" class="w3font" @click="removeHotKey">Remove</div>
         </div>
       </div>
     </div>
@@ -293,47 +293,45 @@ export default class ItemHotkeyTab extends Vue {
 
 <style scoped type="text/css">
 .hotkey-wrapper {
-  padding-top: 20px;
-  padding-left: 60px;
-  padding-right: 60px;
-
-  min-width: 80%;
+  padding-top: 2vh;
+  padding-left: 8vw;
 
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
 }
 
 .item-grid {
   background: url("~@/assets/images/hotkeys/Hotkeys_Inventory_Frame.png") no-repeat center;
-  background-size: cover;
-  padding: 5px;
-  width: 155px;
-  height: 221px;
+  background-size: 100% 100%;
+  padding: 3%;
+  width: min(18vw, 20vh);
+  height: max(28vh, 10vw);
 }
 
 .function-key-grid {
   background: url("~@/assets/images/hotkeys/Hotkeys_Heroes_Frame.png") no-repeat center;
-  background-size: cover;
-  padding: 5px;
-  width: 291px;
-  height: 85px;
+  background-size: 100% 100%;
+  padding: 3%;
+  width: 100%;
+  height: 5%;
 }
 
 .single-item {
   background: url("~@/assets/images/hotkeys/Hotkeys_Inventory_Button.png") no-repeat center;
-  background-size: cover;
+  background-size: 100% 100%;
   cursor: pointer;
   text-align: center;
-  font-size: 16px;
-  line-height: 68px;
-  height: 68px;
-  width: 68px;
+  font-size: 2.4vmin;
+  line-height: 7%;
+  height: 7%;
+  width: 7%;
 }
 
 .item-hover:hover {
   background: url("~@/assets/images/hotkeys/Hotkeys_Button_Highlight.png") no-repeat center;
-  background-size: cover;
-  line-height: 68px;
+  background-size: 100% 100%;
+  line-height: 7%;
 } 
 
 .hotkey-toggle {
@@ -345,11 +343,11 @@ export default class ItemHotkeyTab extends Vue {
 .foot-note {
   text-align: center;
   color: #7f7f7f;
-  font-size: 12px;
+  font-size: 14px;
 
   position: absolute;
-  bottom: -20px;
-  left: 20px;
+  bottom: 1vh;
+  left: 2vw;
 }
 
 .function-item {
@@ -371,17 +369,17 @@ export default class ItemHotkeyTab extends Vue {
 
 .hotkey-tips {
   display: flex;
-  font-size: 13px;
+  font-size: 1.7vmin;
   flex-direction: column;
   align-items: flex-start;
   justify-content: space-around;
-  padding: 20px;
+  padding: 2vw;
   background: url("~@/assets/images/hotkeys/Hotkeys_Inventory_Text_Frame.png") no-repeat center;
-  width: 562px;
-  height: 180px;
-  margin-left: 66px;
-  margin-top: 60px;
-  background-size: cover;
+  width: 92%;
+  height: 24vh;
+  margin-left: 4vw;
+  margin-top: 8vh;
+  background-size: 100% 100%;
 }
 
 .inventory-options {

--- a/src/hot-keys/RaceSpecificHotkeys/RaceSpecificHotkeyTab.vue
+++ b/src/hot-keys/RaceSpecificHotkeys/RaceSpecificHotkeyTab.vue
@@ -20,14 +20,14 @@
         <ItemSelectionContainer style="visibility: hidden" :single-row="true" :on-click="selectUnit" :selection-items="heroes"/>
       </div>
       <div class="hero-wrapper" />
-      <ButtonWarcraft style="position: absolute; bottom: 198px; right: 150px" :on-click="setClassicMode" :text="isClassic" />
-      <ButtonWarcraft style="position: absolute; bottom: 128px; right: 150px" :on-click="importHotkeys" text="Import" />
-      <ButtonWarcraft style="position: absolute; bottom: 58px; right: 150px" :on-click="saveHotkeys" text="Save" />
+      <ButtonWarcraft style="position: absolute; bottom: 21vh; right: 10vw" :on-click="setClassicMode" :text="isClassic" />
+      <ButtonWarcraft style="position: absolute; bottom: 14vh; right: 10vw" :on-click="importHotkeys" text="Import" />
+      <ButtonWarcraft style="position: absolute; bottom: 7vh; right: 10vw" :on-click="saveHotkeys" text="Save" />
     </div>
-    <div style="position:absolute; left: 852px; top: 172px; font-size: 18px;"  class="w3font">
+    <div style="position:absolute; right: 6vw; top: 150px; font-size: 18px;"  class="w3font">
       <span v-if="isResearchAbilitySelected">Train: </span>{{ editAbility.name }}
     </div>
-    <div style="position:absolute; right: 133px; top: 193px" :class="editAbility.icon ? 'visible' : 'hidden'" class="current-selection-container">
+    <div style="position:absolute; right: 6vw; top: 173px" :class="editAbility.icon ? 'visible' : 'hidden'" class="current-selection-container">
       <div style="display: flex; flex-direction: row">
         <div style="height: 64px; width: 64px; margin: 10px; display: flex; cursor: pointer" class="w3font" :class="editAbility.icon"  @click="() => listenToUnhotkeyFunction = false">
           <div style="padding-top: 45px; position: absolute; right: 222px">
@@ -468,7 +468,7 @@ export default class RaceSpecificHotkeyTab extends Vue {
 <style type="text/css">
 
 .race-table-wrapper {
-  width: 100%;
+  width: 700px;
   height: 600px;
   display: flex;
   flex-direction: row;
@@ -478,11 +478,11 @@ export default class RaceSpecificHotkeyTab extends Vue {
 
 .selection-header {
   font-size: 18px;
-  margin-top: 8px;
+  margin-top: 2vh;
 }
 
 .selection-wrapper {
-  margin-left: 50px;
+  margin-left: 4vw;
 }
 
 .visible {

--- a/src/status/StatusScreen.vue
+++ b/src/status/StatusScreen.vue
@@ -91,13 +91,13 @@ export default class StatusScreen extends Vue {
 .status-container{
   position: absolute;
   background: rgba(0, 0, 0, 0.7);
-  top: 167px;
+  top: 19vh;
   left: 0;
   right: 0;
   margin-left: auto;
   margin-right: auto;
-  width: 1128px;
-  height: 580px;
+  width: 90vw;
+  height: 70vh;
   overflow-y: auto;
   padding: 16px;
 }

--- a/src/update-handling/UpdateSettingsScreen.vue
+++ b/src/update-handling/UpdateSettingsScreen.vue
@@ -242,8 +242,8 @@ export default class UpdateSettingsScreen extends Vue {
 
   position:fixed;
   bottom: 5vh;
-  width: 90%;
-  height: 86px;
+  width: 82%;
+  height: 70px;
 
   background: url("~@/assets/images/home/Header_Buttons_Frame_Slim.png") center no-repeat;
   background-size: 100% 100%;
@@ -251,11 +251,11 @@ export default class UpdateSettingsScreen extends Vue {
 
 .button-bar-button {
   font-size: 20px;
-  width: 22vw;
-  height: 60px;
+  width: 20vw;
+  height: 50px;
   text-align: center;
   cursor: pointer;
-  line-height: 60px;
+  line-height: 50px;
   background: url("~@/assets/images/home/Button_Blue.png") center no-repeat;
   background-size: 100% 100%;
 }

--- a/src/update-handling/UpdateSettingsScreen.vue
+++ b/src/update-handling/UpdateSettingsScreen.vue
@@ -27,7 +27,7 @@
           </div>
         </div>
         <div>
-          <div class="options-header w3font" style="margin-top: 20px">Color Settings</div>
+          <div class="options-header w3font" style="margin-top: 15px">Color Settings</div>
           <div class="color-pick-bar">
             <div style="display: flex">
               <div :class="isTeamColorsEnabled ? 'team-colors-on' : 'team-colors-off'" @click="toggleTeamColors"></div>
@@ -228,6 +228,7 @@ export default class UpdateSettingsScreen extends Vue {
 <style scoped type="text/css">
 .launcher-background {
   display: flex;
+  height: 100%;
   flex-direction: column;
   justify-content: space-around;
   align-items: center;
@@ -237,30 +238,31 @@ export default class UpdateSettingsScreen extends Vue {
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-around;
+  justify-content: center;
 
-  margin-top: 50px;
-  width: 915px;
-  height: 71px;
+  position:fixed;
+  bottom: 5vh;
+  width: 90%;
+  height: 86px;
 
   background: url("~@/assets/images/home/Header_Buttons_Frame_Slim.png") center no-repeat;
-  background-size: cover;
+  background-size: 100% 100%;
 }
 
 .button-bar-button {
   font-size: 20px;
-  width: 208px;
-  height: 54px;
+  width: 22vw;
+  height: 60px;
   text-align: center;
   cursor: pointer;
-  line-height: 56px;
+  line-height: 60px;
   background: url("~@/assets/images/home/Button_Blue.png") center no-repeat;
-  background-size: cover;
+  background-size: 100% 100%;
 }
 
 .button-bar-button:active {
   background: url("~@/assets/images/home/Button_Blue_Active.png") center no-repeat;
-  background-size: cover;
+  background-size: 100% 100%;
 }
 
 .reset-button-line {
@@ -301,6 +303,7 @@ export default class UpdateSettingsScreen extends Vue {
 
 .disabled-option {
   color: rgb(140, 137, 137) !important;
+  filter: grayscale();
 }
 
 .reset-button {
@@ -318,18 +321,18 @@ export default class UpdateSettingsScreen extends Vue {
 
 .version-wrapper {
   text-align: right;
-  position: absolute;
-  right: 0;
-  top: 0;
+  position: fixed;
+  right: 5.5vw;
+  top: 20vh;
   font-size: 12px;
 }
 
 .color-pick-bar {
-  margin-top: 10px;
+  margin-top: 1vh;
   background: url("~@/assets/images/home/Header_Buttons_Frame.png") no-repeat center;
-  height: 71px;
+  height: 72px;
   width: 671px;
-  background-size: cover;
+  background-size: 100% 100%;
   display: flex;
   flex-direction: row;
   justify-content: space-around;


### PR DESCRIPTION
This update touches up some of the UI to allow for the launcher to be resized, aimed at making it easier to use for people with small screens and a bit nicer and more customizable for people with large screens.

Quick summary:
- made the top bar buttons partially scale with width
- made news window take up most of the main screen and its text resize with window height
- made some adjustments to the hotkey tab's positionings
- cropped the dark grey part of the status tab to look more in line with the rest of the launcher
- moved version information in settings to the top-right corner
- made the bottom buttom bar in settings & the start button in the main tab anchored to the bottom of the window.

All feedback is welcome! Especially anything pertaining to 1080p and larger screens as I don't have any to test on 😅 