### PR TITLE
Set size after position as multi-monitor fix

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -70,8 +70,8 @@ function createWindow() {
 
   // Create the browser window.
   win = new BrowserWindow({
-    width: _.isUndefined(bounds.width) ? 1275 : bounds.width,
-    height: _.isUndefined(bounds.height) ? 830 : bounds.height,
+    width: 1275,
+    height: 830,
     x: bounds.x,
     y: bounds.y,
     resizable: true,
@@ -85,6 +85,11 @@ function createWindow() {
       webSecurity: false
     }
   });
+
+  // set size after the window is made because electron initially
+  // uses wrong screen bounds when the window is non on primary monitor
+  win.setSize(_.isUndefined(bounds.width) ? 1275 : bounds.width,
+              _.isUndefined(bounds.height) ? 830 : bounds.height, false)
 
   floNetworkTestService.setWindow(win);
   floUtilsService.registerHandlers();


### PR DESCRIPTION
On multi-monitor setups, electron uses the properties of the main screen, which can result in the window size getting clamped down. Setting size after the window is made in the correct position gets around this issue.