### PR TITLE
Settings page scrollable

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -295,4 +295,8 @@ a {
   padding-right: 25%;
 }
 
+.panel-scroll {
+  overflow-y: scroll;
+  scroll-behavior: smooth;
+}
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -294,4 +294,5 @@ a {
   padding-left: 25%;
   padding-right: 25%;
 }
+
 </style>

--- a/src/home/HeadLine.vue
+++ b/src/home/HeadLine.vue
@@ -36,7 +36,6 @@ export default class HeadLine extends Vue {
   flex-direction: row;
   justify-content: space-evenly;
   align-items: center;
-
   width: 100vw;
   height: 13vh;
 }

--- a/src/home/HeadLine.vue
+++ b/src/home/HeadLine.vue
@@ -42,7 +42,6 @@ export default class HeadLine extends Vue {
 }
 
 .headline-wrapper {
-  position: inline;
   margin-left:1%;
   width: 100%;
   height: 15%;

--- a/src/home/NewsBanner.vue
+++ b/src/home/NewsBanner.vue
@@ -8,7 +8,7 @@
       <div class="w3font news-header">{{ selectedNewsDate }}</div>
       <div class="news-banner">
           <div class="news-message-box">
-            <div class="news-content" v-if="isNewsHtml" v-html="selectedNewsMessage"></div>
+            <div class="news-content panel-scroll" v-if="isNewsHtml" v-html="selectedNewsMessage"></div>
             <vue-markdown v-else :source="selectedNewsMessage" />
           </div>
       </div>
@@ -136,8 +136,6 @@ export default class NewsBanner extends Vue {
 }
 
 .news-content {
-  height: 95%;
-  overflow-y: scroll;
-  scroll-behavior: smooth;
+  height: 98%;
 }
 </style>

--- a/src/home/NewsBanner.vue
+++ b/src/home/NewsBanner.vue
@@ -69,7 +69,6 @@ export default class NewsBanner extends Vue {
 <style scoped type="text/css">
 
 .news-container {
-  
   position: relative;
   font-size: 2vh;
   width: 75vw;

--- a/src/home/NewsBanner.vue
+++ b/src/home/NewsBanner.vue
@@ -69,6 +69,7 @@ export default class NewsBanner extends Vue {
 <style scoped type="text/css">
 
 .news-container {
+  
   position: relative;
   font-size: 2vh;
   width: 75vw;
@@ -135,7 +136,7 @@ export default class NewsBanner extends Vue {
 }
 
 .news-content {
-  height: 100%;
+  height: 95%;
   overflow-y: scroll;
   scroll-behavior: smooth;
 }

--- a/src/update-handling/UpdateSettingsScreen.vue
+++ b/src/update-handling/UpdateSettingsScreen.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="launcher-background">
     <LoadingSpinner :style="`visibility: ${isLoading ? 'visible' : 'hidden'}`" />
-    <div style="padding-top: 30px; position: relative">
+    <div class="panel">
       <div class="version-wrapper">
         <div>W3Champions Endpoint: {{selectedEndpoint.id}}</div>
         <div>W3Champions Version: {{w3cVersion}}</div>
@@ -50,20 +50,20 @@
             </div>
           </div>
         </div>
-        <div class="button-bar">
-          <div @click="repairW3c" :disabled="isLoading" class="button-bar-button w3font">
-            Reset W3C
-          </div>
-          <div @click="redownloadW3c" :disabled="isLoading" class="button-bar-button w3font" :class="isW3LocationWrong ? 'disabled-option' : ''" :title="explanationW3Wrong">
-            Redownload
-          </div>
-          <div @click="toggleVersion" class="button-bar-button w3font" :class="isW3LocationWrong ? 'disabled-option' : ''" :title="explanationW3Wrong">
-            Switch to {{ !isTest ? "PTR" : "LIVE" }}
-          </div>
-          <div @click="resetAuthentication" class="button-bar-button w3font">
-            Log out
-          </div>
-        </div>
+      </div>
+    </div>
+    <div class="button-bar">
+      <div @click="repairW3c" :disabled="isLoading" class="button-bar-button w3font">
+        Reset W3C
+      </div>
+      <div @click="redownloadW3c" :disabled="isLoading" class="button-bar-button w3font" :class="isW3LocationWrong ? 'disabled-option' : ''" :title="explanationW3Wrong">
+        Redownload
+      </div>
+      <div @click="toggleVersion" class="button-bar-button w3font" :class="isW3LocationWrong ? 'disabled-option' : ''" :title="explanationW3Wrong">
+        Switch to {{ !isTest ? "PTR" : "LIVE" }}
+      </div>
+      <div @click="resetAuthentication" class="button-bar-button w3font">
+        Log out
       </div>
     </div>
   </div>
@@ -384,8 +384,13 @@ export default class UpdateSettingsScreen extends Vue {
 }
 
 .settings-wrapper {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.panel {
+  overflow-y: scroll;
+  scroll-behavior: smooth;
 }
 </style>

--- a/src/update-handling/UpdateSettingsScreen.vue
+++ b/src/update-handling/UpdateSettingsScreen.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="launcher-background">
     <LoadingSpinner :style="`visibility: ${isLoading ? 'visible' : 'hidden'}`" />
-    <div class="panel">
+    <div class="panel-scroll">
       <div class="version-wrapper">
         <div>W3Champions Endpoint: {{selectedEndpoint.id}}</div>
         <div>W3Champions Version: {{w3cVersion}}</div>
@@ -389,8 +389,4 @@ export default class UpdateSettingsScreen extends Vue {
   align-items: center;
 }
 
-.panel {
-  overflow-y: scroll;
-  scroll-behavior: smooth;
-}
 </style>


### PR DESCRIPTION
Touched up the Settings Page so it resizes nicely. Fixed overflow on the News Banner.

Overflow adjusted:
![image](https://github.com/w3champions/launcher/assets/44567955/e12048fa-8af8-49ab-9911-d2ea8776d294)

Shows scroll bar when overflowing now, and doesnt overlap bottom tools
![image](https://github.com/w3champions/launcher/assets/44567955/1b6c0c29-829f-4199-8ca4-fadba01cb080)

