### PR TITLE
W3C-205 Fix Close of Maximized Launcher; Remember Maximized State

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -20,8 +20,8 @@ declare const __static: string;
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let win: BrowserWindow | null
-let fab: BrowserWindow | null
+let win: BrowserWindow | null;
+let fab: BrowserWindow | null;
 let tray: Tray | null;
 
 const logger = require("electron-log")
@@ -113,11 +113,43 @@ function createWindow() {
 
   win.on('moved', function () {
     setWindowBounds();
-  })
+  });
 
   win.on('resized', function () {
     setWindowBounds();
-  })
+  });
+
+  // Resize happens when user maximizes the window
+  // Without storing the bounds on resize, will freeze
+  // when hiding maximized window.
+  win.on('resize', function () {
+    setWindowBounds();
+  });
+
+  // Show event is triggered when user re-opens launcher from tray
+  // If the user had their launcher maximized, maximize it again.
+  win.on('show', function () {
+    const store = new Store();
+    if (store.get("maximized")) {
+      win.maximize();
+    }
+  });
+
+  // W3C-205 Workaround to properly ascertain whether transparent window is maximized
+  // in ElectronV11 to prevent a freeze when hiding maximized transparent window.
+  // See: https://github.com/electron/electron/issues/12854#issuecomment-602062349
+  win.isMaximized = function () {
+    const nativeIsMaximized = BrowserWindow.prototype.isMaximized.call(this);
+      if (!nativeIsMaximized) {
+        // determine whether the window is full of the screen work area
+        const bounds = getWindowBounds();
+        const workArea = screen.getDisplayMatching(bounds).workArea;
+        if (bounds.x <= workArea.x && bounds.y <= workArea.y && bounds.width >= workArea.width && bounds.height >= workArea.height) {
+          return true;
+        }
+      }
+    return nativeIsMaximized;
+  }.bind(win);
 }
 
 function createTray() {
@@ -284,6 +316,13 @@ async function createFab() {
 }
 
 ipcMain.on('close-window', () => {
+  // W3C-205 Using workaround to hide maximized transparent window in ElectronV11 without freeze
+  // Storing whether the user had their launcher maximized for when they re-open it
+  const store = new Store();
+  store.set("maximized", win?.isMaximized());
+  if (win?.isMaximized()) {
+    win?.maximize();
+  }
   win?.hide();
 });
 


### PR DESCRIPTION
Longer context/investigation on the JIRA task, issue is related to the transparent launcher window and Electron 11.

With a workaround implementation of `isMaximized()`, it's possible to correctly `maximize()` as needed before hiding the launcher. Chose to call original `maximize()` before the `hide()` and not add the other workaround implementations for minimal addition.

Even with workaround - including `getWindowBounds()` caused the freeze again. When the Windows native maximize is used to maximize the transparent window, `resized` event is not triggered. Updating the bounds on `resize` for the maximize (the double-click) resolves the issue again.

Store the state of whether the launcher was maximized before hiding. Restoring from the tray is a `show` event - check if the user had their launcher maximized and maximize it if so.